### PR TITLE
feat: add swapService to SwapProvider

### DIFF
--- a/app/mock-data/mock-apis.ts
+++ b/app/mock-data/mock-apis.ts
@@ -9,9 +9,20 @@ import { mockEthereumNetwork, mockNetworks } from './mock-networks'
 import { mockEthereumTokens } from './mock-tokens'
 import { mockAccount1, mockAccounts } from './mock-accounts'
 import { mockSpotPrices } from './mock-spot-prices'
-import { mockQuoteOptions } from './mock-quote-options'
+import {
+  mockJupiterQuote,
+  mockJupiterSwapTransactions,
+  mockQuoteOptions,
+  mockZeroExQuoteResponse,
+  mockZeroExSwapResponse
+} from './mock-quote-options'
 import { mockExchanges } from './mock-exchanges'
 import { mockNetworkFeeEstimates } from './mock-network-fee-estimates'
+import {
+  JupiterQuoteParams,
+  JupiterSwapParams,
+  ZeroExSwapParams,
+} from "../src/constants/types";
 
 export const getBalance = async (
   address: string,
@@ -87,4 +98,35 @@ export const getExchanges = async () => {
 
 export const getNetworkFeeEstimate = async (chainId: string) => {
   return mockNetworkFeeEstimates[chainId]
+}
+
+export const swapService = {
+  getZeroExPriceQuote: async (params: ZeroExSwapParams) => {
+    return {
+      success: true,
+      response: mockZeroExQuoteResponse,
+      errorResponse: ""
+    }
+  },
+  getZeroExTransactionPayload: async (params: ZeroExSwapParams) => {
+    return {
+      success: true,
+      response: mockZeroExSwapResponse,
+      errorResponse: ""
+    }
+  },
+  getJupiterQuote: async (params: JupiterQuoteParams) => {
+    return {
+      success: true,
+      response: mockJupiterQuote,
+      errorResponse: ""
+    }
+  },
+  getJupiterTransactionsPayload: async (params: JupiterSwapParams) => {
+    return {
+      success: true,
+      response: mockJupiterSwapTransactions,
+      errorResponse: ""
+    }
+  }
 }

--- a/app/mock-data/mock-quote-options.ts
+++ b/app/mock-data/mock-quote-options.ts
@@ -3,7 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import { QuoteOption } from '../src/constants/types'
+import {
+  JupiterQuote,
+  JupiterSwapTransactions,
+  QuoteOption,
+  ZeroExQuoteResponse,
+  ZeroExSwapResponse
+} from '../src/constants/types'
 
 export const mockQuoteOptions: QuoteOption[] = [
   {
@@ -39,3 +45,68 @@ export const mockQuoteOptions: QuoteOption[] = [
     impact: '0.01'
   }
 ]
+
+export const mockZeroExQuoteResponse: ZeroExQuoteResponse = {
+  price: "0.80921",
+  value: "100000000000000000",
+  gas: "240000",
+  estimatedGas: "240000",
+  gasPrice: "61000000000",
+  protocolFee: "0",
+  minimumProtocolFee: "0",
+  buyTokenAddress: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+  buyAmount: "80921",
+  sellTokenAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  sellAmount: "100000000000000000",
+  allowanceTarget: "0x0000000000000000000000000000000000000000",
+  sellTokenToEthRate: "1",
+  buyTokenToEthRate: "0.812697"
+}
+
+export const mockZeroExSwapResponse: ZeroExSwapResponse = {
+  ...mockZeroExQuoteResponse,
+  guaranteedPrice: "0.80063",
+  to: "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+  data: "0x415565b..."
+}
+
+export const mockJupiterQuote: JupiterQuote = {
+  routes: [
+    {
+      inAmount: BigInt(10000),
+      outAmount: BigInt(327),
+      amount: BigInt(10000),
+      otherAmountThreshold: BigInt(324),
+      swapMode: "ExactIn",
+      priceImpactPct: 6.7619243537819784e-12,
+      marketInfos: [
+        {
+          id: "amgK1WE8Cvae4mVdj4AhXSsknWsjaGgo1coYicasBnM",
+          label: "Lifinity",
+          inputMint: "So11111111111111111111111111111111111111112",
+          outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          inAmount: BigInt(10000),
+          outAmount: BigInt(327),
+          lpFee: {
+            amount: BigInt(8),
+            mint: "So11111111111111111111111111111111111111112",
+            pct: 0.0008
+          },
+          platformFee: {
+            amount: BigInt(0),
+            mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            pct: 0
+          },
+          priceImpactPct: 6.761892447563105e-12,
+          notEnoughLiquidity: false
+        }
+      ]
+    }
+  ]
+}
+
+export const mockJupiterSwapTransactions: JupiterSwapTransactions = {
+  setupTransaction: "setup",
+  swapTransaction: "swap",
+  cleanupTransaction: "cleanup"
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2743,7 +2743,7 @@
     },
     "ethereum-blockies": {
       "version": "git+ssh://git@github.com/brave/blockies.git#07ebdfa3ed79fceec8234ef8c880ebdefd79bf0a",
-      "from": "ethereum-blockies@https://github.com/brave/blockies.git"
+      "from": "ethereum-blockies@github:brave/blockies"
     },
     "fs-extra": {
       "version": "10.1.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,7 +32,8 @@ export const App = (props: AppProps) => {
     getSupportedNetworks,
     getBraveWalletAccounts,
     getExchanges,
-    getNetworkFeeEstimate
+    getNetworkFeeEstimate,
+    swapService
   } = props
 
   return (
@@ -46,6 +47,7 @@ export const App = (props: AppProps) => {
         getSelectedNetwork={getSelectedNetwork}
         getTokenPrice={getTokenPrice}
         getSwapQuotes={getSwapQuotes}
+        swapService={swapService}
         getSupportedNetworks={getSupportedNetworks}
         getBraveWalletAccounts={getBraveWalletAccounts}
         getExchanges={getExchanges}

--- a/app/src/constants/types.ts
+++ b/app/src/constants/types.ts
@@ -86,3 +86,89 @@ export type GasEstimate = {
   gasFeeFiat?: string
   time?: string
 }
+
+// Swap Service types
+export type ZeroExSwapParams = {
+  takerAddress: string
+  sellAmount: string
+  buyAmount: string
+  buyToken: string
+  sellToken: string
+  slippagePercentage: number
+  gasPrice: string
+}
+
+export interface ZeroExQuoteResponse {
+  price: string
+  value: string
+  gas: string
+  estimatedGas: string
+  gasPrice: string
+  protocolFee: string
+  minimumProtocolFee: string
+  buyTokenAddress: string
+  sellTokenAddress: string
+  buyAmount: string
+  sellAmount: string
+  allowanceTarget: string
+  sellTokenToEthRate: string
+  buyTokenToEthRate: string
+}
+
+export interface ZeroExSwapResponse extends ZeroExQuoteResponse {
+  guaranteedPrice: string
+  to: string
+  data: string
+}
+
+export type JupiterQuoteParams = {
+  inputMint: string
+  outputMint: string
+  amount: string
+  slippagePercentage: number
+}
+
+export type JupiterFee = {
+  amount: bigint
+  mint: string
+  pct: number
+}
+
+export type JupiterMarketInfo = {
+  id: string
+  label: string
+  inputMint: string
+  outputMint: string
+  notEnoughLiquidity: boolean
+  inAmount: bigint
+  outAmount: bigint
+  priceImpactPct: number
+  lpFee: JupiterFee
+  platformFee: JupiterFee
+}
+
+export type JupiterRoute = {
+  inAmount: bigint
+  outAmount: bigint
+  amount: bigint
+  otherAmountThreshold: bigint
+  swapMode: string
+  priceImpactPct: number
+  marketInfos: JupiterMarketInfo[]
+}
+
+export type JupiterQuote = {
+  routes: JupiterRoute[]
+}
+
+export type JupiterSwapParams = {
+  route: JupiterRoute
+  userPublicKey: string
+  outputMint: string
+}
+
+export type JupiterSwapTransactions = {
+  setupTransaction: string
+  swapTransaction: string
+  cleanupTransaction: string
+}

--- a/app/src/context/swap.context.tsx
+++ b/app/src/context/swap.context.tsx
@@ -12,7 +12,14 @@ import {
   QuoteOption,
   WalletAccount,
   Exchange,
-  GasEstimate
+  GasEstimate,
+  ZeroExSwapParams,
+  ZeroExSwapResponse,
+  JupiterSwapParams,
+  JupiterQuote,
+  JupiterQuoteParams,
+  JupiterSwapTransactions,
+  ZeroExQuoteResponse
 } from '../constants/types'
 
 interface SwapContextInterface {
@@ -49,6 +56,28 @@ interface SwapContextInterface {
     error: number
     errorMessage: string
   }>
+  swapService: {
+    getZeroExPriceQuote: (params: ZeroExSwapParams) => Promise<{
+      success: boolean
+      response: ZeroExQuoteResponse
+      errorResponse: string
+    }>
+    getZeroExTransactionPayload: (params: ZeroExSwapParams) => Promise<{
+      success: boolean
+      response: ZeroExSwapResponse
+      errorResponse: string
+    }>
+    getJupiterQuote: (params: JupiterQuoteParams) => Promise<{
+      success: boolean
+      response: JupiterQuote
+      errorResponse: string
+    }>
+    getJupiterTransactionsPayload: (params: JupiterSwapParams) => Promise<{
+      success: boolean
+      response: JupiterSwapTransactions
+      errorResponse: string
+    }>
+  }
   getSwapQuotes: (
     fromAddress: string,
     fromAmount: string,
@@ -81,7 +110,8 @@ const SwapProvider = (props: SwapProviderInterface) => {
     getSupportedNetworks,
     getBraveWalletAccounts,
     getExchanges,
-    getNetworkFeeEstimate
+    getNetworkFeeEstimate,
+    swapService
   } = props
 
   return (
@@ -98,7 +128,8 @@ const SwapProvider = (props: SwapProviderInterface) => {
         getSupportedNetworks,
         getBraveWalletAccounts,
         getExchanges,
-        getNetworkFeeEstimate
+        getNetworkFeeEstimate,
+        swapService
       }}
     >
       {children}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -21,7 +21,7 @@ import {
   getSupportedNetworks,
   getBraveWalletAccounts,
   getExchanges,
-  getNetworkFeeEstimate
+  getNetworkFeeEstimate, swapService
 } from '../mock-data/mock-apis'
 
 // Utils
@@ -39,6 +39,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
       getSelectedNetwork={getSelectedNetwork}
       getTokenPrice={getTokenPrice}
       getSwapQuotes={getSwapQuotes}
+      swapService={swapService}
       getSupportedNetworks={getSupportedNetworks}
       getBraveWalletAccounts={getBraveWalletAccounts}
       getExchanges={getExchanges}


### PR DESCRIPTION
We should be able to replace `getSwapQuotes` with `swapService` methods now, which is compatible with `SwapService` mojo interface in brave-core.