### PR TITLE
feat(swap): add isSwapSupported to SwapService to match brave-core

### DIFF
--- a/app/mock-data/mock-apis.ts
+++ b/app/mock-data/mock-apis.ts
@@ -119,5 +119,8 @@ export const swapService = {
       response: mockJupiterSwapTransactions,
       errorResponse: ""
     }
+  },
+  isSwapSupported: async (chainId: string) => {
+    return { result: true }
   }
 }

--- a/app/src/context/swap.context.tsx
+++ b/app/src/context/swap.context.tsx
@@ -77,6 +77,9 @@ interface SwapContextInterface {
       response: JupiterSwapResponse
       errorResponse: string
     }>
+    isSwapSupported: (chainId: string) => Promise<{
+      result: boolean
+    }>
   }
   getBraveWalletAccounts?: () => Promise<WalletAccount[]>
   getExchanges: () => Promise<Exchange[]>


### PR DESCRIPTION
This is done to match the mojo service, so we can directly use it in the `swapService` prop.