### PR TITLE
feat(swap): refresh quotes periodically and adjust loader accordingly

### DIFF
--- a/app/src/components/swap/to-section.tsx
+++ b/app/src/components/swap/to-section.tsx
@@ -65,14 +65,12 @@ export const ToSection = (props: Props) => {
             </Text>
           </Row>
         )}
-        {!isLoading && (
-          <SwapInput
-            hasError={hasInputError}
-            onChange={onInputChange}
-            value={inputValue}
-            disabled={disabled}
-          />
-        )}
+        <SwapInput
+          hasError={hasInputError}
+          onChange={onInputChange}
+          value={inputValue}
+          disabled={disabled}
+        />
       </Column>
     </Row>
   )

--- a/app/src/hooks/useJupiter.ts
+++ b/app/src/hooks/useJupiter.ts
@@ -41,7 +41,7 @@ export function useJupiter (params: SwapParams) {
   } = useWalletState()
 
   const refresh = React.useCallback(
-    async function (overrides: Partial<SwapParams>): Promise<Quote> {
+    async function (overrides: Partial<SwapParams> = {}): Promise<Quote> {
       const overriddenParams: SwapParams = {
         ...params,
         ...overrides
@@ -55,6 +55,8 @@ export function useJupiter (params: SwapParams) {
         return {}
       }
       if (!overriddenParams.fromAmount) {
+          setQuote(undefined)
+          setError(undefined)
         return {}
       }
 

--- a/app/src/hooks/useSwap.ts
+++ b/app/src/hooks/useSwap.ts
@@ -83,6 +83,19 @@ export const useSwap = () => {
     slippagePercentage: new Amount(slippageTolerance).div(100).toNumber()
   })
 
+  React.useEffect(() => {
+    const interval = setInterval(async () => {
+      if (selectedNetwork?.coin === CoinType.Solana) {
+        await jupiter.refresh()
+      } else {
+        await zeroEx.refresh()
+      }
+    }, 5000)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [selectedNetwork, zeroEx.refresh, jupiter.refresh])
+
   const quoteOptions: QuoteOption[] = React.useMemo(() => {
     if (!fromToken || !toToken) {
       return []
@@ -196,6 +209,10 @@ export const useSwap = () => {
   const handleOnSetFromAmount = React.useCallback(
     async (value: string) => {
       setFromAmount(value)
+      if (!value) {
+        setToAmount('')
+      }
+
       if (selectedNetwork?.coin === CoinType.Solana) {
         await handleJupiterQuoteRefresh({
           fromAmount: value

--- a/app/src/hooks/useZeroEx.ts
+++ b/app/src/hooks/useZeroEx.ts
@@ -32,7 +32,7 @@ export function useZeroEx (params: SwapParams) {
   } = useWalletState()
 
   const refresh = React.useCallback(
-    async function (overrides: Partial<SwapParams>): Promise<Quote> {
+    async function (overrides: Partial<SwapParams> = {}): Promise<Quote> {
       const overriddenParams: SwapParams = {
         ...params,
         ...overrides
@@ -46,6 +46,8 @@ export function useZeroEx (params: SwapParams) {
         return {}
       }
       if (!overriddenParams.fromAmount && !overriddenParams.toAmount) {
+          setQuote(undefined)
+          setError(undefined)
         return {}
       }
       if (!overriddenParams.takerAddress) {

--- a/app/src/views/swap.tsx
+++ b/app/src/views/swap.tsx
@@ -134,16 +134,15 @@ export const Swap = () => {
             isLoading={isFetchingQuote}
             disabled={selectedNetwork?.coin === CoinType.Solana}
           />
-          {!isFetchingQuote &&
-            selectedNetwork?.coin === CoinType.Solana && (
-              <QuoteOptions
-                options={quoteOptions}
-                selectedQuoteOptionIndex={selectedQuoteOptionIndex}
-                onSelectQuoteOption={onSelectQuoteOption}
-              />
-            )}
+          {selectedNetwork?.coin === CoinType.Solana && (
+            <QuoteOptions
+              options={quoteOptions}
+              selectedQuoteOptionIndex={selectedQuoteOptionIndex}
+              onSelectQuoteOption={onSelectQuoteOption}
+            />
+          )}
         </SwapSectionBox>
-        {quoteOptions.length > 0 && !isFetchingQuote && (
+        {quoteOptions.length > 0 && (
           <>
             <QuoteInfo
               selectedQuoteOption={quoteOptions[selectedQuoteOptionIndex]}


### PR DESCRIPTION
Once a quote has been fetched, subsequent calls to `.refresh()` should not make the previous quote details disappear while another call is in progress.

Also added an effect to invoke `.refresh()` periodically.

⚠️ Note how the To box increases in height while displaying the loader. I was unable to do the fix in CSS.

### Demo

https://user-images.githubusercontent.com/3684187/191546000-c917553f-f94f-4841-9b94-c226e539371b.mov
