### PR TITLE
feat: implement wallet adapters and trigger exchange() on submit

### DIFF
--- a/app/mock-data/mock-apis.ts
+++ b/app/mock-data/mock-apis.ts
@@ -18,8 +18,11 @@ import {
 import { mockExchanges } from './mock-exchanges'
 import { mockNetworkFeeEstimates } from './mock-network-fee-estimates'
 import {
+  ApproveERC20Params,
+  ETHSendTransactionParams,
   JupiterQuoteParams,
   JupiterSwapParams,
+  SOLSendTransactionParams,
   ZeroExSwapParams
 } from '~/constants/types'
 
@@ -132,4 +135,34 @@ export const swapService = {
 
 export const getDefaultBaseCurrency = async () => {
   return { currency: 'USD' }
+}
+
+export const ethWalletAdapter = ({
+  getGasPrice: async (chainId: string) => "0x0001" as string,
+  getGasPrice1559: async (chainId: string) => ({
+    slowMaxPriorityFeePerGas: '0x1',
+    slowMaxFeePerGas: '0x1',
+    avgMaxPriorityFeePerGas: '0x1',
+    avgMaxFeePerGas: '0x1',
+    fastMaxPriorityFeePerGas: '0x1',
+    fastMaxFeePerGas: '0x1',
+    baseFeePerGas: '0x0'
+  }),
+  sendTransaction: async (params: ETHSendTransactionParams) => {
+    await delay(2000)
+  },
+  getERC20ApproveData: async (params: ApproveERC20Params) => {
+    await delay(1000)
+    return [1, 2, 3] as number[]
+  },
+  getERC20Allowance: async (contractAddress: string, ownerAddress: string, spenderAddress: string) => {
+    await delay(1000)
+    return "0x0" as string
+  }
+})
+
+export const solWalletAdapter = {
+  sendTransaction: async (params: SOLSendTransactionParams) => {
+    await delay(2000)
+  }
 }

--- a/app/mock-data/mock-networks.ts
+++ b/app/mock-data/mock-networks.ts
@@ -18,7 +18,7 @@ import {
   OPTIMISMIconUrl
 } from '~/assets/asset-icons'
 
-export const mockEthereumNetwork = {
+export const mockEthereumNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://etherscan.io'],
   chainId: ChainID.ETHEREUM_MAINNET,
   chainName: 'Ethereum',
@@ -27,10 +27,11 @@ export const mockEthereumNetwork = {
   iconUrls: [ETHIconUrl],
   rpcUrls: [''],
   symbol: 'ETH',
-  symbolName: 'Ethereum'
+  symbolName: 'Ethereum',
+  isEIP1559: true
 }
 
-export const mockBinanceNetwork = {
+export const mockBinanceNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://bscscan.com'],
   chainId: ChainID.BINANCE_SMART_CHAIN,
   chainName: 'Binance',
@@ -39,10 +40,11 @@ export const mockBinanceNetwork = {
   iconUrls: [BNBIconUrl],
   rpcUrls: [''],
   symbol: 'BNB',
-  symbolName: 'Binance'
+  symbolName: 'Binance',
+  isEIP1559: false
 }
 
-export const mockPolygonNetwork = {
+export const mockPolygonNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://polygonscan.com'],
   chainId: ChainID.POLYGON,
   chainName: 'Polygon',
@@ -51,10 +53,11 @@ export const mockPolygonNetwork = {
   iconUrls: [MATICIconUrl],
   rpcUrls: [''],
   symbol: 'MATIC',
-  symbolName: 'Polygon'
+  symbolName: 'Polygon',
+  isEIP1559: true
 }
 
-export const mockAvalancheNetwork = {
+export const mockAvalancheNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://snowtrace.io'],
   chainId: ChainID.AVALANCHE,
   chainName: 'Avalanche',
@@ -63,10 +66,11 @@ export const mockAvalancheNetwork = {
   iconUrls: [AVAXIconUrl],
   rpcUrls: [''],
   symbol: 'AVAX',
-  symbolName: 'Avalanche'
+  symbolName: 'Avalanche',
+  isEIP1559: true
 }
 
-export const mockCeloNetwork = {
+export const mockCeloNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://explorer.celo.org'],
   chainId: ChainID.CELO,
   chainName: 'Celo',
@@ -75,10 +79,11 @@ export const mockCeloNetwork = {
   iconUrls: [CELOIconUrl],
   rpcUrls: [''],
   symbol: 'CELO',
-  symbolName: 'CELO'
+  symbolName: 'CELO',
+  isEIP1559: false
 }
 
-export const mockFantomNetwork = {
+export const mockFantomNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://ftmscan.com'],
   chainId: ChainID.FANTOM,
   chainName: 'Fantom',
@@ -87,10 +92,11 @@ export const mockFantomNetwork = {
   iconUrls: [FTMIconUrl],
   rpcUrls: [''],
   symbol: 'FTM',
-  symbolName: 'Fantom'
+  symbolName: 'Fantom',
+  isEIP1559: true
 }
 
-export const mockOptimismNetwork = {
+export const mockOptimismNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://optimistic.etherscan.io'],
   chainId: ChainID.OPTIMISM,
   chainName: 'Optimism',
@@ -99,10 +105,11 @@ export const mockOptimismNetwork = {
   iconUrls: [OPTIMISMIconUrl],
   rpcUrls: [''],
   symbol: 'ETH',
-  symbolName: 'Ether'
+  symbolName: 'Ether',
+  isEIP1559: false
 }
 
-export const mockSolanaNetwork = {
+export const mockSolanaNetwork: NetworkInfo = {
   blockExplorerUrls: ['https://explorer.solana.com/'],
   chainId: ChainID.SOLANA_MAINNET,
   chainName: 'Solana',
@@ -111,7 +118,8 @@ export const mockSolanaNetwork = {
   iconUrls: [SOLIconUrl],
   rpcUrls: [''],
   symbol: 'SOL',
-  symbolName: 'Solana'
+  symbolName: 'Solana',
+  isEIP1559: false
 }
 
 export const mockNetworks: NetworkInfo[] = [

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -33,6 +33,8 @@ export const App = (props: AppProps) => {
     getExchanges,
     getNetworkFeeEstimate,
     getDefaultBaseCurrency,
+    ethWalletAdapter,
+    solWalletAdapter,
     swapService
   } = props
 
@@ -46,12 +48,14 @@ export const App = (props: AppProps) => {
         getSelectedAccount={getSelectedAccount}
         getSelectedNetwork={getSelectedNetwork}
         getTokenPrice={getTokenPrice}
-        swapService={swapService}
         getSupportedNetworks={getSupportedNetworks}
         getBraveWalletAccounts={getBraveWalletAccounts}
         getExchanges={getExchanges}
         getNetworkFeeEstimate={getNetworkFeeEstimate}
         getDefaultBaseCurrency={getDefaultBaseCurrency}
+        ethWalletAdapter={ethWalletAdapter}
+        solWalletAdapter={solWalletAdapter}
+        swapService={swapService}
       >
         <WalletStateProvider>
           <Swap />

--- a/app/src/constants/locale.ts
+++ b/app/src/constants/locale.ts
@@ -8,6 +8,8 @@ import { Registry } from './types'
 export const locale: Registry = {
   braveSwap: 'Swap',
   braveSwapReviewOrder: 'Review order',
+  braveSwapApproveToken: 'Approve $1',
+  braveSwapInsufficientBalance: 'Insufficient $1 balance',
   braveSwapSelectToken: 'Select token',
   braveSwapHalf: 'Half',
   braveSwapMax: 'Max',

--- a/app/src/constants/magics.ts
+++ b/app/src/constants/magics.ts
@@ -8,3 +8,7 @@ export const NATIVE_ASSET_CONTRACT_ADDRESS_0X =
   '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 
 export const WRAPPED_SOL_CONTRACT_ADDRESS = 'So11111111111111111111111111111111111111112'
+
+export const MAX_UINT256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+
+export const ZERO_EX_VALIDATION_ERROR_CODE = 100

--- a/app/src/constants/types.ts
+++ b/app/src/constants/types.ts
@@ -30,6 +30,7 @@ export type NetworkInfo = {
   symbolName: string
   decimals: number
   coin: number
+  isEIP1559: boolean // only for ETH coin type
 }
 
 type LiquiditySource = {
@@ -103,6 +104,18 @@ export type GasEstimate = {
   gasFeeFiat?: string
   time?: string
 }
+
+export type AmountValidationErrorType =
+    | 'fromAmountDecimalsOverflow'
+    | 'toAmountDecimalsOverflow'
+
+export type SwapValidationErrorType =
+    | AmountValidationErrorType
+    | 'insufficientBalance'
+    | 'insufficientFundsForGas'
+    | 'insufficientAllowance'
+    | 'insufficientLiquidity'
+    | 'unknownError'
 
 export type SwapParams = {
   fromToken?: BlockchainToken
@@ -215,4 +228,46 @@ export interface JupiterErrorResponse {
   statusCode: string
   error: string
   message: string
+}
+
+// ETH Wallet Adapter
+export type GasPrice1559 = {
+  slowMaxPriorityFeePerGas: string,
+  slowMaxFeePerGas: string
+  avgMaxPriorityFeePerGas: string,
+  avgMaxFeePerGas: string
+  fastMaxPriorityFeePerGas: string,
+  fastMaxFeePerGas: string
+  baseFeePerGas: string
+}
+export type ETHSendTransactionParams = {
+  from: string
+  to: string
+  value: string
+  data: number[]
+
+  gas?: string
+
+  // Legacy gas pricing
+  gasPrice?: string
+
+  // EIP-1559 gas pricing
+  maxPriorityFeePerGas?: string
+  maxFeePerGas?: string
+}
+export type ApproveERC20Params = {
+  contractAddress: string
+  spenderAddress: string
+  allowance: string
+}
+
+// SOL Wallet Adapter
+export type SOLSendTransactionParams = {
+  encodedTransaction: string
+  from: string
+  sendOptions?: {
+    maxRetries?: number,
+    preflightCommitment?: string,
+    skipPreflight?: boolean
+  }
 }

--- a/app/src/context/swap.context.tsx
+++ b/app/src/context/swap.context.tsx
@@ -18,7 +18,11 @@ import {
   JupiterQuoteResponse,
   JupiterQuoteParams,
   JupiterSwapResponse,
-  ZeroExQuoteResponse
+  ZeroExQuoteResponse,
+  GasPrice1559,
+  ETHSendTransactionParams,
+  ApproveERC20Params,
+  SOLSendTransactionParams
 } from '~/constants/types'
 
 interface SwapContextInterface {
@@ -86,6 +90,16 @@ interface SwapContextInterface {
   getDefaultBaseCurrency?: () => Promise<{
     currency: string
   }>
+  ethWalletAdapter: {
+    getGasPrice: (chainId: string) => Promise<string>,
+    getGasPrice1559: (chainId: string) => Promise<GasPrice1559>
+    sendTransaction: (params: ETHSendTransactionParams) => Promise<void>
+    getERC20Allowance: (contractAddress: string, ownerAddress: string, spenderAddress: string) => Promise<string>
+    getERC20ApproveData: (params: ApproveERC20Params) => Promise<number[]>
+  }
+  solWalletAdapter: {
+    sendTransaction: (params: SOLSendTransactionParams) => Promise<void>
+  }
 }
 
 // Create Swap Context
@@ -111,6 +125,8 @@ const SwapProvider = (props: SwapProviderInterface) => {
     getExchanges,
     getNetworkFeeEstimate,
     getDefaultBaseCurrency,
+    ethWalletAdapter,
+    solWalletAdapter,
     swapService
   } = props
 
@@ -129,6 +145,8 @@ const SwapProvider = (props: SwapProviderInterface) => {
         getExchanges,
         getNetworkFeeEstimate,
         getDefaultBaseCurrency,
+        ethWalletAdapter,
+        solWalletAdapter,
         swapService
       }}
     >

--- a/app/src/hooks/useJupiter.ts
+++ b/app/src/hooks/useJupiter.ts
@@ -33,7 +33,7 @@ export function useJupiter (params: SwapParams) {
   const [selectedRoute, setSelectedRoute] = React.useState<JupiterRoute | undefined>(undefined)
 
   // Context
-  const { swapService } = useSwapContext()
+  const { swapService, solWalletAdapter } = useSwapContext()
 
   // Wallet State
   const {
@@ -55,8 +55,8 @@ export function useJupiter (params: SwapParams) {
         return {}
       }
       if (!overriddenParams.fromAmount) {
-          setQuote(undefined)
-          setError(undefined)
+        setQuote(undefined)
+        setError(undefined)
         return {}
       }
 
@@ -115,13 +115,14 @@ export function useJupiter (params: SwapParams) {
       if (success && response) {
         const { setupTransaction, swapTransaction, cleanupTransaction } = response
 
-        const serializedTransactions = [
-          setupTransaction,
-          swapTransaction,
-          cleanupTransaction
-        ].filter(txn => txn !== '')
-
-        // Sign and submit serializedTransactions sequentially
+        // Ignore setupTransaction and cleanupTransaction
+        await solWalletAdapter.sendTransaction({
+          encodedTransaction: swapTransaction,
+          from: selectedAccount,
+          sendOptions: {
+            skipPreflight: true
+          }
+        })
       } else if (errorResponse) {
         try {
           const err = JSON.parse(errorResponse) as JupiterErrorResponse

--- a/app/src/hooks/useZeroEx.ts
+++ b/app/src/hooks/useZeroEx.ts
@@ -7,11 +7,15 @@ import React from 'react'
 
 // Types / constants
 import { CoinType, SwapParams, ZeroExErrorResponse, ZeroExQuoteResponse } from '~/constants/types'
-import { NATIVE_ASSET_CONTRACT_ADDRESS_0X } from '~/constants/magics'
+import { MAX_UINT256, NATIVE_ASSET_CONTRACT_ADDRESS_0X } from '~/constants/magics'
 
 // Hooks
 import { useSwapContext } from '~/context/swap.context'
 import { useWalletState } from '~/state/wallet'
+
+// Utils
+import Amount from '~/utils/amount'
+import { hexStrToNumberArray } from '~/utils/hex-utils'
 
 type Quote = {
   quote?: ZeroExQuoteResponse
@@ -21,14 +25,15 @@ type Quote = {
 export function useZeroEx (params: SwapParams) {
   const [quote, setQuote] = React.useState<ZeroExQuoteResponse | undefined>(undefined)
   const [error, setError] = React.useState<ZeroExErrorResponse | undefined>(undefined)
+  const [hasAllowance, setHasAllowance] = React.useState<boolean>(false)
   const [loading, setLoading] = React.useState<boolean>(false)
 
   // Context
-  const { swapService } = useSwapContext()
+  const { swapService, ethWalletAdapter } = useSwapContext()
 
   // Wallet State
   const {
-    state: { selectedNetwork }
+    state: { selectedNetwork, selectedAccount }
   } = useWalletState()
 
   const refresh = React.useCallback(
@@ -46,8 +51,8 @@ export function useZeroEx (params: SwapParams) {
         return {}
       }
       if (!overriddenParams.fromAmount && !overriddenParams.toAmount) {
-          setQuote(undefined)
-          setError(undefined)
+        setQuote(undefined)
+        setError(undefined)
         return {}
       }
       if (!overriddenParams.takerAddress) {
@@ -67,6 +72,17 @@ export function useZeroEx (params: SwapParams) {
         })
         if (success && response) {
           setQuote(response)
+          try {
+            const allowance = await ethWalletAdapter.getERC20Allowance(
+              response.sellTokenAddress,
+              selectedAccount,
+              response.allowanceTarget
+            )
+            setHasAllowance(new Amount(allowance).gte(response.sellAmount))
+          } catch (e) {
+            // bubble up error
+          }
+
           return { quote: response, error: undefined }
         } else if (errorResponse) {
           try {
@@ -91,7 +107,7 @@ export function useZeroEx (params: SwapParams) {
   )
 
   const exchange = React.useCallback(
-    async function (overrides: Partial<SwapParams>) {
+    async function (overrides: Partial<SwapParams> = {}) {
       const overriddenParams: SwapParams = {
         ...params,
         ...overrides
@@ -122,9 +138,21 @@ export function useZeroEx (params: SwapParams) {
       })
 
       if (success && response) {
-        const { data } = response
+        const { data, to, value, estimatedGas } = response
 
-        // Sign and submit transaction with data
+        try {
+          await ethWalletAdapter.sendTransaction({
+            from: selectedAccount,
+            to,
+            value: new Amount(value).toHex(),
+            gas: new Amount(estimatedGas).toHex(),
+            data: hexStrToNumberArray(data)
+          })
+
+          setQuote(undefined)
+        } catch (e) {
+          // bubble up error
+        }
       } else if (errorResponse) {
         try {
           const err = JSON.parse(errorResponse) as ZeroExErrorResponse
@@ -136,14 +164,39 @@ export function useZeroEx (params: SwapParams) {
         }
       }
     },
-    [selectedNetwork, params]
+    [selectedNetwork, selectedAccount, params]
   )
+
+  const approve = React.useCallback(async () => {
+    if (!quote || hasAllowance) {
+      return
+    }
+
+    const { allowanceTarget, sellTokenAddress } = quote
+    try {
+      const data = await ethWalletAdapter.getERC20ApproveData({
+        contractAddress: sellTokenAddress,
+        spenderAddress: allowanceTarget,
+        allowance: new Amount(MAX_UINT256).toHex()
+      })
+      await ethWalletAdapter.sendTransaction({
+        from: selectedAccount,
+        to: sellTokenAddress,
+        value: '0x0',
+        data
+      })
+    } catch (e) {
+      // bubble up error
+    }
+  }, [selectedAccount, quote, hasAllowance])
 
   return {
     quote,
     error,
+    hasAllowance,
     loading,
     exchange,
-    refresh
+    refresh,
+    approve
   }
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -11,6 +11,7 @@ import './index.css'
 
 // Mock Data
 import {
+  ethWalletAdapter,
   getBalance,
   getERC20TokenBalance,
   getAllTokens,
@@ -21,8 +22,9 @@ import {
   getBraveWalletAccounts,
   getExchanges,
   getNetworkFeeEstimate,
-  swapService,
-  getDefaultBaseCurrency
+  getDefaultBaseCurrency,
+  solWalletAdapter,
+  swapService
 } from '../mock-data/mock-apis'
 
 // Utils
@@ -39,12 +41,14 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
       getSelectedAccount={getSelectedAccount}
       getSelectedNetwork={getSelectedNetwork}
       getTokenPrice={getTokenPrice}
-      swapService={swapService}
       getSupportedNetworks={getSupportedNetworks}
       getBraveWalletAccounts={getBraveWalletAccounts}
       getExchanges={getExchanges}
       getNetworkFeeEstimate={getNetworkFeeEstimate}
       getDefaultBaseCurrency={getDefaultBaseCurrency}
+      ethWalletAdapter={ethWalletAdapter}
+      solWalletAdapter={solWalletAdapter}
+      swapService={swapService}
     />
   </React.StrictMode>
 )

--- a/app/src/utils/hex-utils.ts
+++ b/app/src/utils/hex-utils.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+export const hexStrToNumberArray = (value: string): number[] => {
+  if (!value) {
+    return []
+  }
+
+  const hexStr = value.startsWith('0x') ? value.slice(2) : value
+  const array = []
+  for (let n = 0; n < hexStr.length; n += 2) {
+    array.push(parseInt(hexStr.substr(n, 2), 16))
+  }
+  return array
+}

--- a/app/src/views/swap.tsx
+++ b/app/src/views/swap.tsx
@@ -76,7 +76,10 @@ export const Swap = () => {
     setSelectedGasFeeOption,
     setSlippageTolerance,
     setUseDirectRoute,
-    setUseOptimizedFees
+    setUseOptimizedFees,
+    onSubmit,
+    submitButtonText,
+    isSubmitButtonDisabled
   } = swap
 
   // Wallet State
@@ -96,10 +99,6 @@ export const Swap = () => {
       setSlippageTolerance('0.5')
     }
   }, [slippageTolerance])
-
-  const onClickReviewOrder = React.useCallback(() => {
-    // Todo: Add logic here to review order
-  }, [])
 
   // render
   return (
@@ -166,12 +165,12 @@ export const Swap = () => {
           </>
         )}
         <StandardButton
-          onClick={onClickReviewOrder}
-          buttonText={getLocale('braveSwapReviewOrder')}
+          onClick={onSubmit}
+          buttonText={submitButtonText}
           buttonType='primary'
           buttonWidth='full'
           verticalMargin={16}
-          disabled={true}
+          disabled={isSubmitButtonDisabled}
         />
         {showSwapSettings && (
           <SwapSettingsModal


### PR DESCRIPTION
No visual changes. The idea is to have an `ethWalletAdapter` and a `solWalletAdapter` containing chain-specific methods, particularly for creating transactions.

Special care was taken to avoid the `useEffect` mess in the legacy implementation of `useSwap` hook.