### PR TITLE
chore: refactor interface to use props + add network/account switcher

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -24,18 +24,20 @@ interface AppProps extends SwapProviderInterface {
 const App = (props: AppProps) => {
   const {
     theme,
+    assetsList,
+    account,
+    network,
+    supportedNetworks,
+    defaultBaseCurrency,
+    exchanges,
+    walletAccounts,
+    switchAccount,
+    switchNetwork,
     getBalance,
     getTokenBalance,
     getLocale,
-    getAllTokens,
-    getSelectedAccount,
-    getSelectedNetwork,
     getTokenPrice,
-    getSupportedNetworks,
-    getBraveWalletAccounts,
-    getExchanges,
     getNetworkFeeEstimate,
-    getDefaultBaseCurrency,
     ethWalletAdapter,
     solWalletAdapter,
     swapService
@@ -44,18 +46,20 @@ const App = (props: AppProps) => {
   return (
     <ThemeProvider theme={theme || defaultTheme}>
       <SwapProvider
+        network={network}
+        account={account}
+        assetsList={assetsList}
+        supportedNetworks={supportedNetworks}
+        defaultBaseCurrency={defaultBaseCurrency}
+        exchanges={exchanges}
+        walletAccounts={walletAccounts}
+        switchAccount={switchAccount}
+        switchNetwork={switchNetwork}
         getBalance={getBalance}
         getTokenBalance={getTokenBalance}
         getLocale={getLocale}
-        getAllTokens={getAllTokens}
-        getSelectedAccount={getSelectedAccount}
-        getSelectedNetwork={getSelectedNetwork}
         getTokenPrice={getTokenPrice}
-        getSupportedNetworks={getSupportedNetworks}
-        getBraveWalletAccounts={getBraveWalletAccounts}
-        getExchanges={getExchanges}
         getNetworkFeeEstimate={getNetworkFeeEstimate}
-        getDefaultBaseCurrency={getDefaultBaseCurrency}
         ethWalletAdapter={ethWalletAdapter}
         solWalletAdapter={solWalletAdapter}
         swapService={swapService}

--- a/interface/src/components/buttons/connect-wallet-button.tsx
+++ b/interface/src/components/buttons/connect-wallet-button.tsx
@@ -15,11 +15,7 @@ import { useWalletState } from '~/state/wallet'
 import { useSwapContext } from '~/context/swap.context'
 
 // Styles
-import {
-  Text,
-  HorizontalSpacer,
-  HiddenResponsiveRow
-} from '~/components/shared.styles'
+import { Text, HorizontalSpacer, HiddenResponsiveRow } from '~/components/shared.styles'
 
 interface Props {
   onClick: () => void
@@ -29,34 +25,28 @@ export const ConnectWalletButton = (props: Props) => {
   const { onClick } = props
 
   // context
-  const { getLocale } = useSwapContext()
+  const { getLocale, account, walletAccounts } = useSwapContext()
 
   // Wallet State
   const { state } = useWalletState()
-  const { selectedAccount, isConnected, braveWalletAccounts } = state
+  const { isConnected } = state
 
   // Memos
   const accountOrb: string = React.useMemo(() => {
     return create({
-      seed: selectedAccount?.address.toLowerCase() || '',
+      seed: account.address.toLowerCase() || '',
       size: 8,
       scale: 16
     }).toDataURL()
-  }, [selectedAccount])
+  }, [account])
 
   const accountName: string = React.useMemo(() => {
-    if (!selectedAccount) {
-      return ''
-    }
-    return (
-      braveWalletAccounts.find((account) => account.address === selectedAccount.address)
-        ?.name ?? ''
-    )
-  }, [selectedAccount, braveWalletAccounts])
+    return walletAccounts.find(account => account.address === account.address)?.name ?? ''
+  }, [account, walletAccounts])
 
   return (
     <Button onClick={onClick} isConnected={isConnected}>
-      {isConnected && selectedAccount ? (
+      {isConnected ? (
         <>
           <AccountCircle orb={accountOrb} />{' '}
           <HiddenResponsiveRow>
@@ -66,7 +56,7 @@ export const ConnectWalletButton = (props: Props) => {
             <HorizontalSpacer size={4} />
           </HiddenResponsiveRow>
           <Text textSize='14px' textColor='text03' isBold={true}>
-            {reduceAddress(selectedAccount.address)}
+            {reduceAddress(account.address)}
           </Text>
         </>
       ) : (
@@ -77,24 +67,22 @@ export const ConnectWalletButton = (props: Props) => {
 }
 
 const Button = styled.button<{ isConnected: boolean }>`
-  background-color: ${(p) =>
+  background-color: ${p =>
     p.isConnected
       ? `var(--connect-wallet-button-background-connected)`
       : `var(--connect-wallet-button-background-disconnected)`};
   border-radius: 48px;
-  color: ${(p) =>
-    p.isConnected ? p.theme.color.legacy.text01 : p.theme.color.white};
+  color: ${p => (p.isConnected ? p.theme.color.legacy.text01 : p.theme.color.white)};
   font-size: 14px;
-  padding: ${(p) => (p.isConnected ? '8px 16px' : `10px 22px`)};
-  box-shadow: ${(p) =>
-    p.isConnected ? '0px 0px 10px rgba(0, 0, 0, 0.05)' : 'none'};
+  padding: ${p => (p.isConnected ? '8px 16px' : `10px 22px`)};
+  box-shadow: ${p => (p.isConnected ? '0px 0px 10px rgba(0, 0, 0, 0.05)' : 'none')};
 `
 
 const AccountCircle = styled.div<{ orb: string }>`
   width: 24px;
   height: 24px;
   border-radius: 100%;
-  background-image: url(${(p) => p.orb});
+  background-image: url(${p => p.orb});
   background-size: cover;
   margin-right: 8px;
 `

--- a/interface/src/components/buttons/select-quote-option-button.tsx
+++ b/interface/src/components/buttons/select-quote-option-button.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 // Context
-import { useWalletState } from '~/state/wallet'
+import { useSwapContext } from '~/context/swap.context'
 
 // Types
 import { QuoteOption } from '~/constants/types'
@@ -27,9 +27,7 @@ export const SelectQuoteOptionButton = (props: Props) => {
   const { onClick, option, isSelected, isBest, spotPrice } = props
 
   // Wallet State
-  const {
-    state: { defaultBaseCurrency }
-  } = useWalletState()
+  const { defaultBaseCurrency } = useSwapContext()
 
   // Methods
   const onSelectToken = React.useCallback(() => {
@@ -37,26 +35,17 @@ export const SelectQuoteOptionButton = (props: Props) => {
   }, [option, onClick])
 
   const quoteFiatValue = React.useMemo(() => {
-    return option.toAmount
-      .times(spotPrice || 0)
-      .formatAsFiat(defaultBaseCurrency)
+    return option.toAmount.times(spotPrice || 0).formatAsFiat(defaultBaseCurrency)
   }, [spotPrice, option, defaultBaseCurrency])
 
   return (
     <Button onClick={onSelectToken} isSelected={isSelected}>
-      {isBest && (
-        <BestOptionBadge isSelected={isSelected}>Best</BestOptionBadge>
-      )}
+      {isBest && <BestOptionBadge isSelected={isSelected}>Best</BestOptionBadge>}
       <Text isBold={true} textColor='text01' textSize='14px' textAlign='left'>
         {option.label}
       </Text>
       <Column horizontalAlign='flex-end'>
-        <Text
-          isBold={true}
-          textColor='text01'
-          textSize='14px'
-          textAlign='right'
-        >
+        <Text isBold={true} textColor='text01' textSize='14px' textAlign='right'>
           {option.toAmount.formatAsAsset(6, option.toToken.symbol)}
         </Text>
         <Text textColor='text03' textSize='14px' textAlign='right'>
@@ -70,10 +59,8 @@ export const SelectQuoteOptionButton = (props: Props) => {
 const Button = styled.button<{
   isSelected: boolean
 }>`
-  --best-background: ${(p) =>
-    p.isSelected
-      ? p.theme.color.legacy.interactive05
-      : p.theme.color.legacy.focusBorder};
+  --best-background: ${p =>
+    p.isSelected ? p.theme.color.legacy.interactive05 : p.theme.color.legacy.focusBorder};
   background-color: var(--select-quote-button-background);
   border-radius: 8px;
   justify-content: space-between;
@@ -82,14 +69,11 @@ const Button = styled.button<{
   margin: 0px 0px 10px 10px;
   position: relative;
   box-sizing: border-box;
-  box-shadow: ${(p) =>
-    p.isSelected
-      ? `0px 0px 0px 1px ${p.theme.color.legacy.interactive05} inset`
-      : 'none'};
+  box-shadow: ${p =>
+    p.isSelected ? `0px 0px 0px 1px ${p.theme.color.legacy.interactive05} inset` : 'none'};
   &:hover {
-    --best-background: ${(p) => p.theme.color.legacy.interactive05};
-    box-shadow: 0px 0px 0px 1px ${(p) => p.theme.color.legacy.interactive05}
-      inset;
+    --best-background: ${p => p.theme.color.legacy.interactive05};
+    box-shadow: 0px 0px 0px 1px ${p => p.theme.color.legacy.interactive05} inset;
   }
 `
 
@@ -98,7 +82,7 @@ const BestOptionBadge = styled.div<{
 }>`
   font-size: 12px;
   line-height: 20px;
-  color: ${(p) => p.theme.color.white};
+  color: ${p => p.theme.color.white};
   border-radius: 7px 7px 7px 0px;
   background-color: var(--best-background);
   padding: 0px 16px;

--- a/interface/src/components/swap/account-selector.tsx
+++ b/interface/src/components/swap/account-selector.tsx
@@ -9,9 +9,6 @@ import styled from 'styled-components'
 // Context
 import { useSwapContext } from '~/context/swap.context'
 
-// Hooks
-import { useWalletState } from '~/state/wallet'
-
 // Types
 import { WalletAccount } from '~/constants/types'
 
@@ -42,12 +39,7 @@ export const AccountSelector = (props: Props) => {
   } = props
 
   // Context
-  const { getLocale } = useSwapContext()
-
-  // Wallet State
-  const {
-    state: { braveWalletAccounts }
-  } = useWalletState()
+  const { getLocale, walletAccounts } = useSwapContext()
 
   // Methods
   const onToggleShowAccountSelector = React.useCallback(() => {
@@ -66,20 +58,14 @@ export const AccountSelector = (props: Props) => {
     <SelectorWrapper>
       <SelectButton onClick={onToggleShowAccountSelector} disabled={disabled}>
         <Text textSize='12px' textColor='text02'>
-          {selectedAccount
-            ? selectedAccount.name
-            : getLocale('braveSwapSelectAccount')}
+          {selectedAccount ? selectedAccount.name : getLocale('braveSwapSelectAccount')}
         </Text>
         <StyledCaratDownIcon size={16} icon={CaratDownIcon} />
       </SelectButton>
       {showAccountSelector && (
         <SelectorBox>
-          {braveWalletAccounts.map((account) => (
-            <AccountListButton
-              account={account}
-              onClick={onClickSelectAccount}
-              key={account.id}
-            />
+          {walletAccounts.map(account => (
+            <AccountListButton account={account} onClick={onClickSelectAccount} key={account.id} />
           ))}
         </SelectorBox>
       )}
@@ -88,8 +74,8 @@ export const AccountSelector = (props: Props) => {
 }
 
 const SelectButton = styled.button`
-  background-color: ${(p) => p.theme.color.legacy.background01};
-  border: 1px solid ${(p) => p.theme.color.legacy.interactive08};
+  background-color: ${p => p.theme.color.legacy.background01};
+  border: 1px solid ${p => p.theme.color.legacy.interactive08};
   border-radius: 4px;
   box-sizing: border-box;
   flex-direction: row;
@@ -107,7 +93,7 @@ const SelectorWrapper = styled.div`
 `
 
 const SelectorBox = styled.div`
-  background-color: ${(p) => p.theme.color.legacy.background01};
+  background-color: ${p => p.theme.color.legacy.background01};
   width: 200px;
   position: absolute;
   z-index: 10;
@@ -120,5 +106,5 @@ const SelectorBox = styled.div`
 `
 
 const StyledCaratDownIcon = styled(Icon)`
-  background-color: ${(p) => p.theme.color.legacy.text01};
+  background-color: ${p => p.theme.color.legacy.text01};
 `

--- a/interface/src/components/swap/network-selector.tsx
+++ b/interface/src/components/swap/network-selector.tsx
@@ -9,7 +9,6 @@ import styled from 'styled-components'
 import { useSwapContext } from '~/context/swap.context'
 
 // Hooks
-import { useWalletState } from '~/state/wallet'
 import { useNetworkFees } from '~/hooks/useNetworkFees'
 
 // Types
@@ -33,12 +32,7 @@ export const NetworkSelector = (props: Props) => {
   const { getNetworkFeeFiatEstimate } = useNetworkFees()
 
   // Context
-  const { getLocale } = useSwapContext()
-
-  // Wallet State
-  const {
-    state: { supportedNetworks }
-  } = useWalletState()
+  const { getLocale, supportedNetworks } = useSwapContext()
 
   return (
     <SelectorBox isHeader={isHeader}>
@@ -54,12 +48,8 @@ export const NetworkSelector = (props: Props) => {
       <VerticalSpacer size={8} />
       <VerticalDivider />
       <VerticalSpacer size={4} />
-      {supportedNetworks.map((network) => (
-        <NetworkListButton
-          key={network.chainId}
-          onClick={onSelectNetwork}
-          network={network}
-        />
+      {supportedNetworks.map(network => (
+        <NetworkListButton key={network.chainId} onClick={onSelectNetwork} network={network} />
       ))}
     </SelectorBox>
   )
@@ -68,16 +58,16 @@ export const NetworkSelector = (props: Props) => {
 const SelectorBox = styled.div<{
   isHeader?: boolean
 }>`
-  background-color: ${(p) => p.theme.color.legacy.background01};
+  background-color: ${p => p.theme.color.legacy.background01};
   width: 222px;
   position: absolute;
   padding-bottom: 4px;
   z-index: 10;
-  top: ${(p) => (p.isHeader ? 42 : 40)}px;
+  top: ${p => (p.isHeader ? 42 : 40)}px;
   box-shadow: 0px 0px 16px var(--network-selector-shadow-color);
-  right: ${(p) => (p.isHeader ? 'unset' : '-10px')};
-  border-radius: ${(p) => (p.isHeader ? 16 : 4)}px;
+  right: ${p => (p.isHeader ? 'unset' : '-10px')};
+  border-radius: ${p => (p.isHeader ? 16 : 4)}px;
   @media screen and (max-width: 800px) {
-    left: ${(p) => (p.isHeader ? '0px' : 'unset')};
+    left: ${p => (p.isHeader ? '0px' : 'unset')};
   }
 `

--- a/interface/src/components/swap/quote-info.tsx
+++ b/interface/src/components/swap/quote-info.tsx
@@ -52,11 +52,11 @@ export const QuoteInfo = (props: Props) => {
   const { getNetworkFeeFiatEstimate } = useNetworkFees()
 
   // Context
-  const { getLocale } = useSwapContext()
+  const { getLocale, network } = useSwapContext()
 
   // Wallet State
   const { state } = useWalletState()
-  const { spotPrices, selectedNetwork } = state
+  const { spotPrices } = state
 
   // State
   const [showAdvanced, setShowAdvanced] = React.useState<boolean>(false)
@@ -67,9 +67,7 @@ export const QuoteInfo = (props: Props) => {
       return ''
     }
 
-    return `1 ${
-      selectedQuoteOption.fromToken.symbol
-    } ≈ ${selectedQuoteOption.rate.format(6)} ${
+    return `1 ${selectedQuoteOption.fromToken.symbol} ≈ ${selectedQuoteOption.rate.format(6)} ${
       selectedQuoteOption.toToken.symbol
     }`
   }, [selectedQuoteOption])
@@ -86,8 +84,7 @@ export const QuoteInfo = (props: Props) => {
       const toTokenPrice = spotPrices.takerAsset
       const coinGeckoRate = Number(toTokenPrice) / Number(fromTokenPrice)
       const coinGeckoMinimumReceived = Number(toAmount) * coinGeckoRate
-      const impact =
-        selectedQuoteOption.toAmount.toNumber() / coinGeckoMinimumReceived
+      const impact = selectedQuoteOption.toAmount.toNumber() / coinGeckoMinimumReceived
       return impact.toFixed(2)
     }
     return ''
@@ -105,10 +102,7 @@ export const QuoteInfo = (props: Props) => {
       return ''
     }
 
-    return selectedQuoteOption.minimumToAmount.formatAsAsset(
-      6,
-      selectedQuoteOption.toToken.symbol
-    )
+    return selectedQuoteOption.minimumToAmount.formatAsAsset(6, selectedQuoteOption.toToken.symbol)
   }, [selectedQuoteOption])
 
   // Methods
@@ -120,7 +114,7 @@ export const QuoteInfo = (props: Props) => {
   }, [fromToken, toToken])
 
   const toggleShowAdvanced = React.useCallback(() => {
-    setShowAdvanced((prev) => !prev)
+    setShowAdvanced(prev => !prev)
   }, [])
 
   return (
@@ -138,18 +132,11 @@ export const QuoteInfo = (props: Props) => {
           <Row rowWidth='full' marginBottom={10} horizontalPadding={16}>
             <HorizontalSpacer size={1} />
             <Row>
-              <Text
-                textSize='14px'
-                textColor={coinGeckoImpact > swapImpact ? 'error' : 'text01'}
-              >
+              <Text textSize='14px' textColor={coinGeckoImpact > swapImpact ? 'error' : 'text01'}>
                 {`< ${coinGeckoImpact}%`} {getLocale('braveSwapCoinGecko')}
               </Text>
               <HorizontalSpacer size={4} />
-              <Link
-                rel='noopener noreferrer'
-                target='_blank'
-                href={coinGeckoAPIURL}
-              >
+              <Link rel='noopener noreferrer' target='_blank' href={coinGeckoAPIURL}>
                 {getLocale('braveSwapAPI')} {`>`}
               </Link>
             </Row>
@@ -171,16 +158,12 @@ export const QuoteInfo = (props: Props) => {
           </Row>
           {selectedQuoteOption && selectedQuoteOption.sources.length > 0 && (
             <Row rowWidth='full' marginBottom={8} horizontalPadding={16}>
-              <Text textSize='14px'>
-                {getLocale('braveSwapLiquidityProvider')}
-              </Text>
+              <Text textSize='14px'>{getLocale('braveSwapLiquidityProvider')}</Text>
               <Row>
                 {selectedQuoteOption.sources.map((source, idx) => (
                   <>
                     <Bubble>
-                      <Text textSize='14px'>
-                        {source.name.split('_').join(' ')}
-                      </Text>
+                      <Text textSize='14px'>{source.name.split('_').join(' ')}</Text>
                       {LPMetadata[source.name] ? (
                         <LPIcon icon={LPMetadata[source.name]} size={16} />
                       ) : null}
@@ -202,15 +185,15 @@ export const QuoteInfo = (props: Props) => {
         <Text textSize='14px'>{getLocale('braveSwapNetworkFee')}</Text>
         <Bubble>
           <FuelTank icon={FuelTankIcon} size={12} />
-          <Text textSize='14px'>
-            {selectedNetwork ? getNetworkFeeFiatEstimate(selectedNetwork) : ''}
-          </Text>
+          <Text textSize='14px'>{getNetworkFeeFiatEstimate(network)}</Text>
         </Bubble>
       </Row>
       <VerticalDivider />
       <Row rowWidth='full' horizontalAlign='center' verticalPadding={7} horizontalPadding={16}>
         <AdvancedButton onClick={toggleShowAdvanced}>
-          <Text textSize='14px' textColor='text03'>{getLocale('braveSwapAdvanced')}</Text>
+          <Text textSize='14px' textColor='text03'>
+            {getLocale('braveSwapAdvanced')}
+          </Text>
           <HorizontalSpacer size={8} />
           <Arrow icon={CaratDownIcon} isSelected={showAdvanced} size={12} />
         </AdvancedButton>
@@ -221,12 +204,12 @@ export const QuoteInfo = (props: Props) => {
 }
 
 const HorizontalArrows = styled(Icon)`
-  background-color: ${(p) => p.theme.color.legacy.text03};
+  background-color: ${p => p.theme.color.legacy.text03};
   margin-left: 8px;
 `
 
 const FuelTank = styled(Icon)`
-  background-color: ${(p) => p.theme.color.legacy.text02};
+  background-color: ${p => p.theme.color.legacy.text02};
   margin-right: 6px;
 `
 
@@ -235,8 +218,8 @@ const AdvancedButton = styled.button`
 `
 
 const Arrow = styled(Icon)<{ isSelected: boolean }>`
-  background-color: ${(p) => p.theme.color.legacy.text03};
-  transform: ${(p) => (p.isSelected ? 'rotate(180deg)' : 'unset')};
+  background-color: ${p => p.theme.color.legacy.text03};
+  transform: ${p => (p.isSelected ? 'rotate(180deg)' : 'unset')};
   transition: transform 300ms ease;
 `
 
@@ -258,12 +241,12 @@ const Link = styled.a`
 `
 
 const LPIcon = styled.div<{ icon: string; size: number }>`
-  background-image: url(${(p) => p.icon});
+  background-image: url(${p => p.icon});
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  height: ${(p) => p.size}px;
-  width: ${(p) => p.size}px;
+  height: ${p => p.size}px;
+  width: ${p => p.size}px;
   margin-left: 6px;
   border-radius: 50px;
 `

--- a/interface/src/components/swap/search-with-network-selector.tsx
+++ b/interface/src/components/swap/search-with-network-selector.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components'
 import { useSwapContext } from '~/context/swap.context'
 
 // Hooks
-import { useWalletState } from '~/state/wallet'
 import { useWalletDispatch } from '~/state/wallet'
 
 // Types
@@ -34,26 +33,17 @@ export const SearchWithNetworkSelector = (props: Props) => {
   const { onSearchChanged, searchValue, networkSelectorDisabled } = props
 
   // Context
-  const { getLocale } = useSwapContext()
-
-  // Dispatch
-  const { dispatch } = useWalletDispatch()
-
-  // Wallet State
-  const {
-    state: { selectedNetwork }
-  } = useWalletState()
+  const { getLocale, network, switchNetwork } = useSwapContext()
 
   // State
-  const [showNetworkSelector, setShowNetworkSelector] =
-    React.useState<boolean>(false)
+  const [showNetworkSelector, setShowNetworkSelector] = React.useState<boolean>(false)
 
   const onSelectNetwork = React.useCallback(
-    (network: NetworkInfo) => {
-      dispatch({ type: 'updateSelectedNetwork', payload: network })
+    async (network: NetworkInfo) => {
+      await switchNetwork(network)
       setShowNetworkSelector(false)
     },
-    [dispatch]
+    [switchNetwork]
   )
 
   return (
@@ -67,23 +57,21 @@ export const SearchWithNetworkSelector = (props: Props) => {
       <HorizontalDivider marginRight={8} height={24} />
       <SelectorWrapper>
         <SelectTokenOrNetworkButton
-          icon={selectedNetwork?.iconUrls[0]}
-          onClick={() => setShowNetworkSelector((prev) => !prev)}
-          text={selectedNetwork?.chainName}
+          icon={network.iconUrls[0]}
+          onClick={() => setShowNetworkSelector(prev => !prev)}
+          text={network.chainName}
           buttonSize='small'
           disabled={networkSelectorDisabled}
         />
-        {showNetworkSelector && (
-          <NetworkSelector onSelectNetwork={onSelectNetwork} />
-        )}
+        {showNetworkSelector && <NetworkSelector onSelectNetwork={onSelectNetwork} />}
       </SelectorWrapper>
     </Wrapper>
   )
 }
 
 const Wrapper = styled.div`
-  background-color: ${(p) => p.theme.color.legacy.background01};
-  border: 1px solid ${(p) => p.theme.color.legacy.disabled};
+  background-color: ${p => p.theme.color.legacy.background01};
+  border: 1px solid ${p => p.theme.color.legacy.disabled};
   border-radius: 4px;
   box-sizing: border-box;
   flex-direction: row;

--- a/interface/src/components/swap/select-token-modal.tsx
+++ b/interface/src/components/swap/select-token-modal.tsx
@@ -40,11 +40,11 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
     const { onClose, onSelectToken, getAssetBalance, disabledToken, selectingFromOrTo } = props
 
     // Context
-    const { getLocale } = useSwapContext()
+    const { getLocale, assetsList } = useSwapContext()
 
     // Wallet State
     const {
-      state: { isConnected, tokenList }
+      state: { isConnected }
     } = useWalletState()
 
     // State
@@ -70,14 +70,14 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
 
     const filteredTokenListBySearch: BlockchainToken[] = React.useMemo(() => {
       if (searchValue === '') {
-        return tokenList
+        return assetsList
       }
-      return tokenList.filter(
+      return assetsList.filter(
         (token: BlockchainToken) =>
           token.name.toLowerCase().startsWith(searchValue.toLowerCase()) ||
           token.symbol.toLowerCase().startsWith(searchValue.toLowerCase())
       )
-    }, [tokenList, searchValue])
+    }, [assetsList, searchValue])
 
     const tokenListWithBalances: BlockchainToken[] = React.useMemo(() => {
       return filteredTokenListBySearch.filter((token: BlockchainToken) =>

--- a/interface/src/components/swap/settings/gas-preset-button.tsx
+++ b/interface/src/components/swap/settings/gas-preset-button.tsx
@@ -26,11 +26,7 @@ export const GasPresetButton = (props: Props) => {
   const { onClick, isSelected, option, gasEstimates } = props
 
   // Context
-  const { getLocale } = useSwapContext()
-
-  // Wallet State
-  const { state } = useWalletState()
-  const { selectedNetwork } = state
+  const { getLocale, network } = useSwapContext()
 
   return (
     <Button onClick={onClick} isSelected={isSelected}>
@@ -52,7 +48,7 @@ export const GasPresetButton = (props: Props) => {
           {gasEstimates.gasFeeGwei} {getLocale('braveSwapGwei')}
         </Text>
         <Text textColor='text03' textSize='12px' isBold={false}>
-          {gasEstimates.gasFee} {selectedNetwork?.symbol}
+          {gasEstimates.gasFee} {network?.symbol}
         </Text>
       </Column>
     </Button>
@@ -65,13 +61,11 @@ const Button = styled.button<{
   display: flex;
   justify-content: space-between;
   width: 100%;
-  background-color: ${(p) => p.theme.color.legacy.background01};
+  background-color: ${p => p.theme.color.legacy.background01};
   border-radius: 8px;
   border: 1px solid
-    ${(p) =>
-      p.isSelected
-        ? 'var(--gas-preset-button-border-selected)'
-        : p.theme.color.legacy.divider01};
+    ${p =>
+      p.isSelected ? 'var(--gas-preset-button-border-selected)' : p.theme.color.legacy.divider01};
   padding: 12px 16px;
   margin-bottom: 8px;
   &:hover {

--- a/interface/src/components/swap/settings/swap-settings-modal.tsx
+++ b/interface/src/components/swap/settings/swap-settings-modal.tsx
@@ -67,14 +67,14 @@ export const SwapSettingsModal = (props: Props) => {
   } = props
 
   // Context
-  const { getLocale } = useSwapContext()
+  const { getLocale, network, exchanges } = useSwapContext()
 
   // Dispatch
   const { dispatch } = useWalletDispatch()
 
   // Wallet State
   const {
-    state: { selectedNetwork, supportedExchanges, userSelectedExchanges }
+    state: { userSelectedExchanges }
   } = useWalletState()
 
   // State
@@ -83,16 +83,16 @@ export const SwapSettingsModal = (props: Props) => {
   // Methods
   const handleCheckExchange = React.useCallback(
     (id: string, checked: boolean) => {
-      const exchange = supportedExchanges.find((e) => e.id === id)
+      const exchange = exchanges.find(e => e.id === id)
       if (checked && exchange !== undefined) {
         const addedList = [exchange, ...userSelectedExchanges]
         dispatch({ type: 'updateUserSelectedExchanges', payload: addedList })
         return
       }
-      const removedList = userSelectedExchanges.filter((e) => e.id !== id)
+      const removedList = userSelectedExchanges.filter(e => e.id !== id)
       dispatch({ type: 'updateUserSelectedExchanges', payload: removedList })
     },
-    [userSelectedExchanges, supportedExchanges, dispatch]
+    [userSelectedExchanges, exchanges, dispatch]
   )
 
   // Memos
@@ -101,9 +101,7 @@ export const SwapSettingsModal = (props: Props) => {
   }, [slippageTolerance])
 
   const modalTitle: string = React.useMemo(() => {
-    return showExchanges
-      ? getLocale('braveSwapExchanges')
-      : getLocale('braveSwapSettings')
+    return showExchanges ? getLocale('braveSwapExchanges') : getLocale('braveSwapSettings')
   }, [showExchanges])
 
   // render
@@ -115,11 +113,7 @@ export const SwapSettingsModal = (props: Props) => {
           {modalTitle}
         </Text>
         {showExchanges && (
-          <IconButton
-            icon={CloseIcon}
-            onClick={() => setShowExchanges(false)}
-            size={20}
-          />
+          <IconButton icon={CloseIcon} onClick={() => setShowExchanges(false)} size={20} />
         )}
       </Row>
 
@@ -128,12 +122,10 @@ export const SwapSettingsModal = (props: Props) => {
         <>
           <VerticalSpacer size={24} />
           <ExchangesColumn>
-            {supportedExchanges.map((exchange) => (
+            {exchanges.map(exchange => (
               <StandardCheckbox
                 id={exchange.id}
-                isChecked={userSelectedExchanges.some(
-                  (e) => e.id === exchange.id
-                )}
+                isChecked={userSelectedExchanges.some(e => e.id === exchange.id)}
                 label={exchange.name}
                 key={exchange.id}
                 onChange={handleCheckExchange}
@@ -155,7 +147,7 @@ export const SwapSettingsModal = (props: Props) => {
           >
             <Row marginBottom={22} rowWidth='full'>
               <Row horizontalAlign='flex-start'>
-                {slippagePresets.map((preset) => (
+                {slippagePresets.map(preset => (
                   <StandardButton
                     buttonText={`${preset}%`}
                     onClick={() => setSlippageTolerance(preset)}
@@ -168,16 +160,13 @@ export const SwapSettingsModal = (props: Props) => {
                   />
                 ))}
               </Row>
-              <SlippageInput
-                onChange={setSlippageTolerance}
-                value={customSlippageInputValue}
-              />
+              <SlippageInput onChange={setSlippageTolerance} value={customSlippageInputValue} />
             </Row>
           </ExpandSection>
           <VerticalDivider />
 
           {/* Ethereum Only Settings */}
-          {selectedNetwork?.coin === CoinType.Ethereum && (
+          {network.coin === CoinType.Ethereum && (
             <>
               {/* Exchanges */}
               <ExpandSection
@@ -191,10 +180,10 @@ export const SwapSettingsModal = (props: Props) => {
               <ExpandSection
                 label={getLocale('braveSwapNetworkFee')}
                 value={`$${gasEstimates.gasFeeFiat}`}
-                secondaryValue={`${gasEstimates.gasFee} ${selectedNetwork.symbol}`}
+                secondaryValue={`${gasEstimates.gasFee} ${network.symbol}`}
               >
                 <Column columnWidth='full'>
-                  {gasFeeOptions.map((option) => (
+                  {gasFeeOptions.map(option => (
                     <GasPresetButton
                       option={option}
                       isSelected={selectedGasFeeOption === option}
@@ -209,7 +198,7 @@ export const SwapSettingsModal = (props: Props) => {
           )}
 
           {/* Solana Only Settings */}
-          {selectedNetwork?.coin === CoinType.Solana && (
+          {network.coin === CoinType.Solana && (
             <>
               {/* Direct Route Toggle */}
               <ToggleSection
@@ -236,7 +225,7 @@ export const SwapSettingsModal = (props: Props) => {
 }
 
 const Modal = styled.div`
-  background-color: ${(p) => p.theme.color.legacy.background02};
+  background-color: ${p => p.theme.color.legacy.background02};
   border-radius: 16px;
   border: 1px solid var(--swap-settings-modal-border-color);
   box-shadow: var(--swap-settings-modal-box-shadow);

--- a/interface/src/components/swap/swap-container.tsx
+++ b/interface/src/components/swap/swap-container.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 // Hooks
-import { useWalletState } from '~/state/wallet'
+import { useSwapContext } from '~/context/swap.context'
 
 // Components
 import { Header } from './header'
@@ -19,9 +19,7 @@ interface Props {
 export const SwapContainer = (props: Props) => {
   const { children } = props
 
-  // Wallet State
-  const { state } = useWalletState()
-  const { selectedNetwork } = state
+  const { network } = useSwapContext()
 
   // State
   const [backgroundHeight, setBackgroundHeight] = React.useState<number>(0)
@@ -42,7 +40,7 @@ export const SwapContainer = (props: Props) => {
     setBackgroundOpacity(0.6)
     // Changes network background opacity back to 0.3 after 1 second
     setTimeout(() => setBackgroundOpacity(0.3), 1000)
-  }, [selectedNetwork])
+  }, [network])
 
   return (
     <Wrapper>
@@ -50,7 +48,7 @@ export const SwapContainer = (props: Props) => {
       <Container ref={ref}>{children}</Container>
       <Background
         height={backgroundHeight}
-        network={selectedNetwork?.chainName?.toLowerCase() ?? ''}
+        network={network.chainName?.toLowerCase() ?? ''}
         backgroundOpacity={backgroundOpacity}
       />
     </Wrapper>
@@ -82,11 +80,7 @@ const Background = styled.div<{
     rgb(93, 124, 209) 50%,
     rgb(122, 96, 232) 100%
   );
-  --ethereum: linear-gradient(
-    125deg,
-    rgb(98, 126, 234) 0%,
-    rgb(129, 152, 238) 100%
-  );
+  --ethereum: linear-gradient(125deg, rgb(98, 126, 234) 0%, rgb(129, 152, 238) 100%);
   --polygon: linear-gradient(
     125deg,
     rgb(130, 71, 229) 0%,
@@ -125,18 +119,18 @@ const Background = styled.div<{
   );
   filter: blur(150px);
   width: 512px;
-  height: ${(p) => p.height}px;
-  opacity: ${(p) => p.backgroundOpacity};
+  height: ${p => p.height}px;
+  opacity: ${p => p.backgroundOpacity};
   transition-delay: 0s;
   transition-duration: 1s;
   transition-timing-function: ease;
   position: absolute;
   z-index: 8;
-  background-image: var(--${(p) => p.network});
+  background-image: var(--${p => p.network});
 `
 
 const Container = styled.div`
-  background-color: ${(p) => p.theme.color.legacy.background01};
+  background-color: ${p => p.theme.color.legacy.background01};
   border-radius: 24px;
   box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
   box-sizing: border-box;

--- a/interface/src/context/swap.context.tsx
+++ b/interface/src/context/swap.context.tsx
@@ -34,10 +34,12 @@ interface SwapContextInterface {
     coin: number,
     chainId: string
   ) => Promise<string>
-  getAllTokens: (chainId: string, coin: number) => Promise<BlockchainToken[]>
-  getSelectedAccount: () => Promise<WalletAccount>
-  getSelectedNetwork: () => Promise<NetworkInfo>
-  getSupportedNetworks: () => Promise<NetworkInfo[]>
+  assetsList: BlockchainToken[]
+  account: WalletAccount
+  network: NetworkInfo
+  supportedNetworks: NetworkInfo[]
+  switchAccount: (account: WalletAccount) => Promise<void>
+  switchNetwork: (network: NetworkInfo) => Promise<void>
   getTokenPrice: (contractAddress: string) => Promise<string>
   swapService: {
     getZeroExPriceQuote: (params: ZeroExSwapParams) => Promise<ZeroExQuoteResponse>
@@ -46,10 +48,10 @@ interface SwapContextInterface {
     getJupiterTransactionsPayload: (params: JupiterSwapParams) => Promise<JupiterSwapResponse>
     isSwapSupported: (chainId: string) => Promise<boolean>
   }
-  getBraveWalletAccounts?: () => Promise<WalletAccount[]>
-  getExchanges: () => Promise<Exchange[]>
+  walletAccounts: WalletAccount[]
+  exchanges: Exchange[]
   getNetworkFeeEstimate: (chainId: string) => Promise<GasEstimate>
-  getDefaultBaseCurrency?: () => Promise<string>
+  defaultBaseCurrency: string
   ethWalletAdapter: {
     getGasPrice: (chainId: string) => Promise<string>
     getGasPrice1559: (chainId: string) => Promise<GasPrice1559>
@@ -77,18 +79,20 @@ export interface SwapProviderInterface extends SwapContextInterface {
 const SwapProvider = (props: SwapProviderInterface) => {
   const {
     children,
+    assetsList,
+    network,
+    account,
+    supportedNetworks,
+    exchanges,
+    walletAccounts,
+    defaultBaseCurrency,
+    switchAccount,
+    switchNetwork,
     getLocale,
     getBalance,
     getTokenBalance,
-    getAllTokens,
-    getSelectedAccount,
-    getSelectedNetwork,
     getTokenPrice,
-    getSupportedNetworks,
-    getBraveWalletAccounts,
-    getExchanges,
     getNetworkFeeEstimate,
-    getDefaultBaseCurrency,
     ethWalletAdapter,
     solWalletAdapter,
     swapService
@@ -97,18 +101,20 @@ const SwapProvider = (props: SwapProviderInterface) => {
   return (
     <SwapContext.Provider
       value={{
+        assetsList,
+        network,
+        account,
+        supportedNetworks,
+        exchanges,
+        walletAccounts,
+        defaultBaseCurrency,
+        switchAccount,
+        switchNetwork,
         getLocale,
         getBalance,
         getTokenBalance,
-        getAllTokens,
-        getSelectedAccount,
-        getSelectedNetwork,
         getTokenPrice,
-        getSupportedNetworks,
-        getBraveWalletAccounts,
-        getExchanges,
         getNetworkFeeEstimate,
-        getDefaultBaseCurrency,
         ethWalletAdapter,
         solWalletAdapter,
         swapService

--- a/interface/src/hooks/useNetworkFees.ts
+++ b/interface/src/hooks/useNetworkFees.ts
@@ -7,6 +7,7 @@ import React from 'react'
 
 // Hooks
 import { useWalletState } from '~/state/wallet'
+import { useSwapContext } from '~/context/swap.context'
 
 // Utils
 import Amount from '~/utils/amount'
@@ -15,9 +16,11 @@ import Amount from '~/utils/amount'
 import { NetworkInfo } from '~/constants/types'
 
 export const useNetworkFees = () => {
+  const { defaultBaseCurrency } = useSwapContext()
+
   // Wallet State
   const {
-    state: { spotPrices, networkFeeEstimates, defaultBaseCurrency }
+    state: { spotPrices, networkFeeEstimates }
   } = useWalletState()
 
   const getNetworkFeeFiatEstimate = React.useCallback(
@@ -29,6 +32,9 @@ export const useNetworkFees = () => {
         return ''
       }
 
+      // FIXME - this should be coming from quotes
+      // networkFeeEstimates should be removed or kept purely
+      // for presentational purpose
       return new Amount(spotPrices.nativeAsset)
         .times(networkFeeEstimates[network.chainId].gasFee)
         .formatAsFiat(defaultBaseCurrency)

--- a/interface/src/state/types.ts
+++ b/interface/src/state/types.ts
@@ -3,29 +3,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import {
-  BlockchainToken,
-  Registry,
-  NetworkInfo,
-  WalletAccount,
-  Exchange,
-  GasEstimate,
-  SpotPrices
-} from '~/constants/types'
+import { Registry, Exchange, GasEstimate, SpotPrices } from '~/constants/types'
 
 export type WalletState = {
   tokenBalances: Registry
   spotPrices: SpotPrices
-  tokenList: BlockchainToken[]
-  selectedAccount: WalletAccount | undefined
-  selectedNetwork: NetworkInfo | undefined
-  supportedNetworks: NetworkInfo[]
   isConnected: boolean
-  braveWalletAccounts: WalletAccount[]
-  supportedExchanges: Exchange[]
   userSelectedExchanges: Exchange[]
   networkFeeEstimates: Record<string, GasEstimate>
-  defaultBaseCurrency: string
 }
 
 type UpdateTokenBalances = {
@@ -36,36 +21,6 @@ type UpdateTokenBalances = {
 type UpdateSpotPrices = {
   type: 'updateSpotPrices'
   payload: Partial<SpotPrices>
-}
-
-type UpdateTokenList = {
-  type: 'updateTokenList'
-  payload: BlockchainToken[]
-}
-
-type UpdateSelectedNetwork = {
-  type: 'updateSelectedNetwork'
-  payload: NetworkInfo
-}
-
-type UpdateSupportedNetworks = {
-  type: 'updateSupportedNetworks'
-  payload: NetworkInfo[]
-}
-
-type UpdateSelectedAccount = {
-  type: 'updateSelectedAccount'
-  payload: WalletAccount
-}
-
-type UpdateBraveWalletAccounts = {
-  type: 'updateBraveWalletAccounts'
-  payload: WalletAccount[]
-}
-
-type UpdateSupportedExchanges = {
-  type: 'updateSupportedExchanges'
-  payload: Exchange[]
 }
 
 type UpdateUserSelectedExchanges = {
@@ -86,12 +41,6 @@ type SetIsConnected = {
 export type WalletActions =
   | UpdateTokenBalances
   | UpdateSpotPrices
-  | UpdateTokenList
-  | UpdateSelectedNetwork
-  | UpdateSelectedAccount
-  | UpdateBraveWalletAccounts
-  | UpdateSupportedNetworks
-  | UpdateSupportedExchanges
   | UpdateUserSelectedExchanges
   | SetIsConnected
   | UpdateDefaultBaseCurrency

--- a/interface/src/views/swap.tsx
+++ b/interface/src/views/swap.tsx
@@ -84,13 +84,8 @@ export const Swap = () => {
     swapValidationError
   } = swap
 
-  // Wallet State
-  const {
-    state: { selectedNetwork }
-  } = useWalletState()
-
   // Context
-  const { getLocale } = useSwapContext()
+  const { getLocale, network } = useSwapContext()
 
   // State
   const [showSwapSettings, setShowSwapSettings] = React.useState<boolean>(false)
@@ -158,9 +153,9 @@ export const Swap = () => {
             onInputChange={handleOnSetToAmount}
             hasInputError={swapValidationError === 'toAmountDecimalsOverflow'}
             isLoading={isFetchingQuote}
-            disabled={selectedNetwork?.coin === CoinType.Solana}
+            disabled={network?.coin === CoinType.Solana}
           />
-          {selectedNetwork?.coin === CoinType.Solana && quoteOptions.length > 0 && (
+          {network.coin === CoinType.Solana && quoteOptions.length > 0 && (
             <QuoteOptions
               options={quoteOptions}
               selectedQuoteOptionIndex={selectedQuoteOptionIndex}

--- a/sites/mock/mock-data/mock-apis.ts
+++ b/sites/mock/mock-data/mock-apis.ts
@@ -5,9 +5,7 @@
 
 // Mock Data
 import { mockEVMNetworksData } from './mock-api-data'
-import { mockEthereumNetwork, mockNetworks } from './mock-networks'
-import { mockEthereumTokens } from './mock-tokens'
-import { mockAccount1, mockAccounts } from './mock-accounts'
+import { mockEthereumNetwork } from './mock-networks'
 import { mockSpotPrices } from './mock-spot-prices'
 import {
   mockJupiterQuote,
@@ -15,7 +13,6 @@ import {
   mockZeroExQuoteResponse,
   mockZeroExSwapResponse
 } from './mock-quote-options'
-import { mockExchanges } from './mock-exchanges'
 import { mockNetworkFeeEstimates } from './mock-network-fee-estimates'
 import {
   ApproveERC20Params,
@@ -47,25 +44,6 @@ export const getTokenBalance = async (
   return balance ?? '0'
 }
 
-export const getAllTokens = async (chainId: string, coin: number) => {
-  if (coin === mockEthereumNetwork.coin && chainId === mockEthereumNetwork.chainId) {
-    return mockEthereumTokens
-  }
-  return []
-}
-
-export const getSelectedAccount = async () => {
-  return mockAccount1
-}
-
-export const getBraveWalletAccounts = async () => {
-  return mockAccounts
-}
-
-export const getSelectedNetwork = async () => {
-  return mockEthereumNetwork
-}
-
 export const getTokenPrice = async (contractAddress: string) => {
   const price = mockSpotPrices[contractAddress]
   if (!price) {
@@ -73,14 +51,6 @@ export const getTokenPrice = async (contractAddress: string) => {
   }
 
   return price
-}
-
-export const getSupportedNetworks = async () => {
-  return mockNetworks
-}
-
-export const getExchanges = async () => {
-  return mockExchanges
 }
 
 export const getNetworkFeeEstimate = async (chainId: string) => {
@@ -105,10 +75,6 @@ export const swapService = {
   isSwapSupported: async (chainId: string) => {
     return true
   }
-}
-
-export const getDefaultBaseCurrency = async () => {
-  return 'USD'
 }
 
 export const ethWalletAdapter = {

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",

--- a/sites/mock/src/main.tsx
+++ b/sites/mock/src/main.tsx
@@ -1,46 +1,58 @@
 import React from 'react'
 import * as ReactDOM from 'react-dom'
 
-import { Swap } from '@brave/swap-interface'
+import { Swap, WalletAccount, NetworkInfo } from '@brave/swap-interface'
 import '@brave/swap-interface/style.css'
 
 import { getLocale } from './utils/locale'
 import {
   ethWalletAdapter,
-  getAllTokens,
   getBalance,
-  getBraveWalletAccounts,
-  getDefaultBaseCurrency,
   getTokenBalance,
-  getExchanges,
   getNetworkFeeEstimate,
-  getSelectedAccount,
-  getSelectedNetwork,
-  getSupportedNetworks,
   getTokenPrice,
   solWalletAdapter,
   swapService
 } from '../mock-data/mock-apis'
+import { mockEthereumTokens } from '../mock-data/mock-tokens'
+import { mockEthereumNetwork, mockNetworks } from '../mock-data/mock-networks'
+import { mockAccount1, mockAccounts } from '../mock-data/mock-accounts'
+import { mockExchanges } from '../mock-data/mock-exchanges'
 
 ReactDOM.render(
   <React.StrictMode>
+    <SwapContainer />
+  </React.StrictMode>,
+  document.getElementById('root') as HTMLElement
+)
+
+function SwapContainer () {
+  const [account, setAccount] = React.useState<WalletAccount>(mockAccount1)
+  const [network, setNetwork] = React.useState<NetworkInfo>(mockEthereumNetwork)
+
+  return (
     <Swap
+      assetsList={mockEthereumTokens}
+      account={account}
+      network={network}
+      supportedNetworks={mockNetworks}
+      walletAccounts={mockAccounts}
+      exchanges={mockExchanges}
+      defaultBaseCurrency='USD'
+      switchAccount={async (account: WalletAccount) => {
+        setAccount(account)
+      }}
+      switchNetwork={async (network: NetworkInfo) => {
+        setNetwork(network)
+      }}
       getLocale={getLocale}
       getBalance={getBalance}
       getTokenBalance={getTokenBalance}
-      getAllTokens={getAllTokens}
-      getSelectedAccount={getSelectedAccount}
-      getSelectedNetwork={getSelectedNetwork}
       getTokenPrice={getTokenPrice}
-      getSupportedNetworks={getSupportedNetworks}
-      getBraveWalletAccounts={getBraveWalletAccounts}
-      getExchanges={getExchanges}
       getNetworkFeeEstimate={getNetworkFeeEstimate}
-      getDefaultBaseCurrency={getDefaultBaseCurrency}
       ethWalletAdapter={ethWalletAdapter}
       solWalletAdapter={solWalletAdapter}
       swapService={swapService}
     />
-  </React.StrictMode>,
-  document.getElementById('root') as HTMLElement
-)
+  )
+}


### PR DESCRIPTION
Using React props for stuff like `selectedAccount`, `selectedNetwork`, etc, allows us to avoid maintaining a state and update it whenever the caller (brave-core in our case) has a change.

Also added switcher methods for network and account.