### PR TITLE
Fix broken exchange() implementation for 0x swaps

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/hooks/useZeroEx.ts
+++ b/interface/src/hooks/useZeroEx.ts
@@ -55,13 +55,17 @@ export function useZeroEx (params: SwapParams) {
       try {
         response = await swapService.getZeroExPriceQuote({
           takerAddress: overriddenParams.takerAddress,
-          sellAmount: new Amount(overriddenParams.fromAmount)
-            .multiplyByDecimals(overriddenParams.fromToken.decimals)
-            .format(),
+          sellAmount:
+            overriddenParams.fromAmount &&
+            new Amount(overriddenParams.fromAmount)
+              .multiplyByDecimals(overriddenParams.fromToken.decimals)
+              .format(),
           sellToken: overriddenParams.fromToken.contractAddress || NATIVE_ASSET_CONTRACT_ADDRESS_0X,
-          buyAmount: new Amount(overriddenParams.toAmount)
-            .multiplyByDecimals(overriddenParams.toToken.decimals)
-            .format(),
+          buyAmount:
+            overriddenParams.toAmount &&
+            new Amount(overriddenParams.toAmount)
+              .multiplyByDecimals(overriddenParams.toToken.decimals)
+              .format(),
           buyToken: overriddenParams.toToken.contractAddress || NATIVE_ASSET_CONTRACT_ADDRESS_0X,
           slippagePercentage: overriddenParams.slippagePercentage,
           gasPrice: ''
@@ -132,10 +136,14 @@ export function useZeroEx (params: SwapParams) {
       try {
         response = await swapService.getZeroExTransactionPayload({
           takerAddress: overriddenParams.takerAddress,
-          sellAmount: overriddenParams.fromAmount,
-          buyAmount: overriddenParams.toAmount,
-          buyToken: overriddenParams.toToken.contractAddress,
-          sellToken: overriddenParams.fromToken.contractAddress,
+          sellAmount: new Amount(overriddenParams.fromAmount)
+            .multiplyByDecimals(overriddenParams.fromToken.decimals)
+            .format(),
+          sellToken: overriddenParams.fromToken.contractAddress || NATIVE_ASSET_CONTRACT_ADDRESS_0X,
+          buyAmount: new Amount(overriddenParams.toAmount)
+            .multiplyByDecimals(overriddenParams.toToken.decimals)
+            .format(),
+          buyToken: overriddenParams.toToken.contractAddress || NATIVE_ASSET_CONTRACT_ADDRESS_0X,
           slippagePercentage: overriddenParams.slippagePercentage,
           gasPrice: ''
         })

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",


### PR DESCRIPTION
No demo available, since `exchange()` creates an actual transaction.