### PR TITLE
Externalize font to prevent brave-core from crashing

### DIFF
--- a/interface/src/index.css
+++ b/interface/src/index.css
@@ -6,7 +6,6 @@
 /* This file will be a work in progress, but the goal is to set as much
 default values here to prevent code duplication in styled components */
 
-@import url('https://fonts.googleapis.com/css?family=Poppins|Poppins:300,400,500,600,700');
 @import '@brave/leo/build/css/variables.css';
 @import './theme/component-variables.css';
 

--- a/sites/mock/src/index.css
+++ b/sites/mock/src/index.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css?family=Poppins|Poppins:300,400,500,600,700');

--- a/sites/mock/src/main.tsx
+++ b/sites/mock/src/main.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom'
 
 import { Swap, WalletAccount, NetworkInfo } from '@brave/swap-interface'
 import '@brave/swap-interface/style.css'
+import './index.css'
 
 import { getLocale } from './utils/locale'
 import {


### PR DESCRIPTION
### Demo

Compiled `style.css` no longer contains the HTTP url of the font, which would otherwise crash brave-core