### PR TITLE
feat: optimise fetching of blockchain state on network/account switch

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/components/swap/account-modal/account-modal.tsx
+++ b/interface/src/components/swap/account-modal/account-modal.tsx
@@ -10,14 +10,14 @@ import styled from 'styled-components'
 import DisconnectIcon from '~/assets/disconnect-icon.svg'
 import HelpIcon from '~/assets/info-icon.svg'
 
-// Hiding Porfolio Section until we support it.
+// Hiding Portfolio Section until we support it.
 // import PortfolioIcon from '~/assets/portfolio-icon.svg'
 
 // Context
 import { useSwapContext } from '~/context/swap.context'
 
 // Types
-import { WalletAccount } from '~/constants/types'
+import { RefreshBlockchainStateParams, WalletAccount } from '~/constants/types'
 
 // Components
 import { AccountListItemButton } from './account-list-item-button'
@@ -35,19 +35,26 @@ import {
 
 interface Props {
   onHideModal: () => void
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
 }
 
 export const AccountModal = (props: Props) => {
-  const { onHideModal } = props
+  const { onHideModal, refreshBlockchainState } = props
 
   // Context
-  const { getLocale, routeBackToWallet, walletAccounts, switchAccount, disconnectWallet } =
+  const { getLocale, routeBackToWallet, walletAccounts, network, switchAccount, disconnectWallet } =
     useSwapContext()
+
+  // Memos
+  const networkAccounts = React.useMemo(() => {
+      return walletAccounts.filter(account => account.coin === network.coin)
+  }, [walletAccounts, network])
 
   // Methods
   const onSelectAccount = React.useCallback(
     async (account: WalletAccount) => {
       await switchAccount(account)
+      await refreshBlockchainState({ account })
       onHideModal()
     },
     [onHideModal, switchAccount]
@@ -98,7 +105,7 @@ export const AccountModal = (props: Props) => {
             {getLocale('braveSwapAccounts')}
           </Text>
         </Row>
-        {walletAccounts.map((account) => (
+        {networkAccounts.map((account) => (
           <AccountListItemButton
             key={account.id}
             address={account.address}

--- a/interface/src/components/swap/account-selector.tsx
+++ b/interface/src/components/swap/account-selector.tsx
@@ -42,10 +42,15 @@ export const AccountSelector = (props: Props) => {
   } = props
 
   // Context
-  const { getLocale, walletAccounts } = useSwapContext()
+  const { getLocale, walletAccounts, network } = useSwapContext()
 
   // Refs
   const accountSelectorRef = React.useRef<HTMLDivElement>(null)
+
+  // Memos
+  const networkAccounts = React.useMemo(() => {
+    return walletAccounts.filter(account => account.coin === network.coin)
+  }, [walletAccounts, network])
 
   // Methods
   const onToggleShowAccountSelector = React.useCallback(() => {
@@ -78,7 +83,7 @@ export const AccountSelector = (props: Props) => {
       </SelectButton>
       {showAccountSelector && (
         <SelectorBox>
-          {walletAccounts.map(account => (
+          {networkAccounts.map(account => (
             <AccountListButton account={account} onClick={onClickSelectAccount} key={account.id} />
           ))}
         </SelectorBox>

--- a/interface/src/components/swap/header.tsx
+++ b/interface/src/components/swap/header.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components'
 import { BRAVE_SWAP_DATA_THEME_KEY } from '../../constants/magics'
 
 // Types
-import { NetworkInfo } from '~/constants/types'
+import { NetworkInfo, RefreshBlockchainStateParams } from '~/constants/types'
 
 // Utils
 import { reduceNetworkDisplayName } from '~/utils/reduce-network-name'
@@ -28,7 +28,13 @@ import { useOnClickOutside } from '~/hooks/useOnClickOutside'
 // Styled Components
 import { Row, HorizontalSpacer, StyledDiv } from '~/components/shared.styles'
 
-export const Header = () => {
+interface Props {
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
+}
+
+export const Header = (props: Props) => {
+  const { refreshBlockchainState } = props
+
   // Wallet State
   const { network, supportedNetworks, isWalletConnected, connectWallet, switchNetwork } =
     useSwapContext()
@@ -44,8 +50,9 @@ export const Header = () => {
   // Methods
   const onSelectNetwork = React.useCallback(async (network: NetworkInfo) => {
     await switchNetwork(network)
+    await refreshBlockchainState({ network })
     setShowNetworkSelector(false)
-  }, [switchNetwork])
+  }, [switchNetwork, refreshBlockchainState])
 
   const toggleTheme = React.useCallback(() => {
     // Users local theme
@@ -133,7 +140,7 @@ export const Header = () => {
           <ConnectWalletButton
             onClick={onClickConnectWalletButton}
           />
-          {showAccountModal && <AccountModal onHideModal={() => setShowAccountModal(false)} />}
+          {showAccountModal && <AccountModal refreshBlockchainState={refreshBlockchainState} onHideModal={() => setShowAccountModal(false)} />}
         </SelectorWrapper>
       </Row>
     </Wrapper>

--- a/interface/src/components/swap/network-selector.tsx
+++ b/interface/src/components/swap/network-selector.tsx
@@ -27,7 +27,7 @@ import {
 } from '~/components/shared.styles'
 
 interface Props {
-  onSelectNetwork: (network: NetworkInfo) => void
+  onSelectNetwork: (network: NetworkInfo) => Promise<void>
   isHeader?: boolean
 }
 

--- a/interface/src/components/swap/search-with-network-selector.tsx
+++ b/interface/src/components/swap/search-with-network-selector.tsx
@@ -13,7 +13,7 @@ import { reduceNetworkDisplayName } from '~/utils/reduce-network-name'
 import { useSwapContext } from '~/context/swap.context'
 
 // Types
-import { NetworkInfo } from '~/constants/types'
+import { NetworkInfo, RefreshBlockchainStateParams } from '~/constants/types'
 
 // Components
 import { SelectTokenOrNetworkButton } from '~/components/buttons'
@@ -27,10 +27,11 @@ interface Props {
   onSearchChanged: (value: string) => void
   searchValue: string
   networkSelectorDisabled: boolean
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
 }
 
 export const SearchWithNetworkSelector = (props: Props) => {
-  const { onSearchChanged, searchValue, networkSelectorDisabled } = props
+  const { onSearchChanged, refreshBlockchainState, searchValue, networkSelectorDisabled } = props
 
   // Context
   const { getLocale, network, switchNetwork } = useSwapContext()
@@ -41,6 +42,7 @@ export const SearchWithNetworkSelector = (props: Props) => {
   const onSelectNetwork = React.useCallback(
     async (network: NetworkInfo) => {
       await switchNetwork(network)
+      await refreshBlockchainState({ network })
       setShowNetworkSelector(false)
     },
     [switchNetwork]

--- a/interface/src/components/swap/swap-container.tsx
+++ b/interface/src/components/swap/swap-container.tsx
@@ -15,12 +15,16 @@ import { Header } from './header'
 // Styled Components
 import { StyledDiv } from '~/components/shared.styles'
 
+// Types
+import { RefreshBlockchainStateParams } from '~/constants/types'
+
 interface Props {
   children?: React.ReactNode
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
 }
 
 export const SwapContainer = (props: Props) => {
-  const { children } = props
+  const { children, refreshBlockchainState } = props
 
   const { network } = useSwapContext()
 
@@ -47,7 +51,7 @@ export const SwapContainer = (props: Props) => {
 
   return (
     <Wrapper>
-      <Header />
+      <Header refreshBlockchainState={refreshBlockchainState} />
       <Container ref={ref}>{children}</Container>
       <Background
         height={backgroundHeight}

--- a/interface/src/constants/types.ts
+++ b/interface/src/constants/types.ts
@@ -74,6 +74,15 @@ export type SwapAndSend = {
   name: string
 }
 
+export type RefreshBlockchainStateParams = {
+  network: NetworkInfo
+  account: WalletAccount
+}
+
+export type RefreshPricesParams = {
+  network: NetworkInfo
+}
+
 export enum CoinType {
   Solana = 501,
   Ethereum = 60

--- a/interface/src/state/wallet.tsx
+++ b/interface/src/state/wallet.tsx
@@ -9,13 +9,6 @@ import React, { useReducer, useContext, createContext } from 'react'
 import { WalletState, Dispatch, WalletActions } from './types'
 import { Registry, GasEstimate } from '~/constants/types'
 
-// Context
-import { useSwapContext } from '~/context/swap.context'
-
-// Utils
-import Amount from '~/utils/amount'
-import { useNativeAsset } from '~/hooks/useNativeAsset'
-
 // Create Wallet State Context
 const WalletStateContext = createContext<{ state: WalletState } | undefined>(undefined)
 
@@ -58,89 +51,8 @@ interface WalletStateProviderInterface {
 const WalletStateProvider = (props: WalletStateProviderInterface) => {
   const { children } = props
 
-  // Swap Methods
-  const { assetsList, network, account, getBalance, getTokenPrice, getTokenBalance } =
-    useSwapContext()
-
   // Wallet State
   const [state, dispatch] = useReducer(WalletReducer, initialState)
-  const nativeAsset = useNativeAsset()
-
-  React.useEffect(() => {
-    // Fetch spot price for native asset, and update the state. During
-    // initialisation, the default asset is always the native one.
-    getTokenPrice(nativeAsset).then(result => {
-      dispatch({
-        type: 'updateSpotPrices',
-        payload: {
-          nativeAsset: Amount.normalize(result),
-          makerAsset: Amount.normalize(result)
-        }
-      })
-    })
-
-    const balancesPromise = Promise.all(
-      assetsList.map(async asset => {
-        try {
-          const result = asset.isToken
-            ? await getTokenBalance(
-              asset.contractAddress,
-              account.address,
-              account.coin,
-              asset.chainId
-            )
-            : await getBalance(account.address, network.coin, network.chainId)
-
-          return {
-            key: asset.contractAddress.toLowerCase(),
-            value: Amount.normalize(result)
-          }
-        } catch (e) {
-          console.error(`Error querying balance: error=${e} asset=`, JSON.stringify(asset))
-          return {
-            key: asset.contractAddress.toLowerCase(),
-            value: ''
-          }
-        }
-      })
-    )
-
-    ;(async () => {
-      const balances = await balancesPromise
-
-      // In the following code block, we're doing the following transformation:
-      // {key: string, value: string}[] => { [key]: value }
-      //
-      // The balances array can be quite big, and copying the accumulated object
-      // for each .reduce() pass can result in an overheard. We're therefore using
-      // a mutable accumulator object, instead of Object.assign() or spread syntax.
-      //
-      // We also return a comma expression, which evaluates the expression
-      // before the comma and returns the expression after the comma. This prevents
-      // unnecessary assignments and object copy.
-      //
-      // We also filter out balance results from the array that could not be
-      // fetched.
-      const payload = balances
-        .filter(item => item.value !== '')
-        .reduce((obj, item) => (((obj as any)[item.key] = item.value), obj), {})
-
-      await dispatch({
-        type: 'updateTokenBalances',
-        payload
-      })
-    })()
-  }, [
-    assetsList,
-    account,
-    network.coin,
-    network.chainId,
-    nativeAsset,
-    getTokenPrice,
-    getBalance,
-    getTokenBalance,
-    dispatch
-  ])
 
   return (
     <WalletStateContext.Provider value={{ state }}>

--- a/interface/src/views/swap.tsx
+++ b/interface/src/views/swap.tsx
@@ -84,7 +84,9 @@ export const Swap = () => {
     onSubmit,
     submitButtonText,
     isSubmitButtonDisabled,
-    swapValidationError
+    swapValidationError,
+    refreshBlockchainState,
+    getNetworkAssetsList
   } = swap
 
   // Context
@@ -127,7 +129,7 @@ export const Swap = () => {
   // render
   return (
     <>
-      <SwapContainer>
+      <SwapContainer refreshBlockchainState={refreshBlockchainState} >
         <Row
           rowWidth='full'
           horizontalPadding={16}
@@ -227,6 +229,8 @@ export const Swap = () => {
           disabledToken={selectingFromOrTo === 'from' ? toToken : fromToken}
           getAssetBalance={getAssetBalance}
           selectingFromOrTo={selectingFromOrTo}
+          refreshBlockchainState={refreshBlockchainState}
+          getNetworkAssetsList={getNetworkAssetsList}
         />
       )}
     </>

--- a/sites/mock/mock-data/mock-tokens.ts
+++ b/sites/mock/mock-data/mock-tokens.ts
@@ -9,7 +9,6 @@ import { BlockchainToken, CoinType } from '@brave/swap-interface'
 // Icons
 import {
   BATIconUrl,
-  ETHIconUrl,
   BNBIconUrl,
   SOLIconUrl,
   USDCIconUrl,
@@ -21,18 +20,6 @@ import {
 } from '../src/assets/asset-icons'
 
 export const mockEthereumTokens: BlockchainToken[] = [
-  {
-    contractAddress: '',
-    name: 'Ethereum',
-    symbol: 'ETH',
-    logo: ETHIconUrl,
-    isToken: false,
-    decimals: 18,
-    visible: true,
-    coingeckoId: 'ethereum',
-    coin: CoinType.Ethereum,
-    chainId: '0x1'
-  },
   {
     contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
     name: 'Basic Attention Token',

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",


### PR DESCRIPTION
### What changed?

`walletAccounts` and `assetsList` now contain information for all networks.

On changing the network or account, we filter the above lists on the fly and use them for refreshing the blockchain state. This ensures consistency. In the event that the account is inconsistent with the network, we again `walletAccounts` to get the first account with the right `coin` value.