### PR TITLE
fix: partition balances by coin type and chainId

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/hooks/useSwap.ts
+++ b/interface/src/hooks/useSwap.ts
@@ -34,7 +34,7 @@ import {
 // Utils
 import Amount from '~/utils/amount'
 import { ZERO_EX_VALIDATION_ERROR_CODE } from '~/constants/magics'
-import { makeNetworkAsset } from '~/utils/assets'
+import { getBalanceRegistryKey, makeNetworkAsset } from '~/utils/assets'
 
 const hasDecimalsOverflow = (amount: string, asset?: BlockchainToken) => {
   if (!asset) {
@@ -310,6 +310,8 @@ export const useSwap = () => {
       const networkAssets = getNetworkAssetsList(overriddenParams.network)
       const balancesPromise = Promise.all(
         networkAssets.map(async asset => {
+          const balanceRegistryKey = getBalanceRegistryKey(asset)
+
           try {
             const result = asset.isToken
               ? await getTokenBalance(
@@ -325,13 +327,13 @@ export const useSwap = () => {
               )
 
             return {
-              key: asset.contractAddress.toLowerCase(),
+              key: balanceRegistryKey,
               value: Amount.normalize(result)
             }
           } catch (e) {
             console.error(`Error querying balance: error=${e} asset=`, JSON.stringify(asset))
             return {
-              key: asset.contractAddress.toLowerCase(),
+              key: balanceRegistryKey,
               value: ''
             }
           }
@@ -465,9 +467,9 @@ export const useSwap = () => {
 
   const getAssetBalance = React.useCallback(
     (token: BlockchainToken): Amount => {
-      return tokenBalances
-        ? new Amount(tokenBalances[token.contractAddress.toLowerCase()] ?? '0')
-        : Amount.zero()
+      const balanceRegistryKey = getBalanceRegistryKey(token)
+
+      return tokenBalances ? new Amount(tokenBalances[balanceRegistryKey] ?? '0') : Amount.zero()
     },
     [tokenBalances]
   )

--- a/interface/src/utils/assets.ts
+++ b/interface/src/utils/assets.ts
@@ -14,3 +14,7 @@ export const makeNetworkAsset = (network: NetworkInfo): BlockchainToken => {
     coin: network.coin
   }
 }
+
+export const getBalanceRegistryKey = (asset: BlockchainToken) => {
+  return `${asset.coin}-${asset.chainId}-${asset.contractAddress.toLowerCase()}`
+}

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",


### PR DESCRIPTION
Previously, when you changed the network, you'd see the balances of the old network for a few seconds until the fresh balances were updated. This PR prevents displaying such stale information in the frontend.