### PR TITLE
feat: throttle async requests to improve performance

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
         "@types/react-window": "^1.8.2",
         "@types/styled-components": "^5.1.25",
+        "async": "^3.2.4",
         "bignumber.js": "^9.1.0",
         "ethereum-blockies": "github:brave/blockies",
         "react": "^16.14.0",
@@ -21,6 +22,7 @@
         "styled-components": "^5.3.5"
       },
       "devDependencies": {
+        "@types/async": "^3.2.15",
         "@types/node": "^18.7.20",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.1",
@@ -1660,6 +1662,12 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true
     },
+    "node_modules/@types/async": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+      "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -2007,6 +2015,11 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -8976,6 +8989,12 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true
     },
+    "@types/async": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+      "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -9278,6 +9297,11 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "asynckit": {
       "version": "0.4.0",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",
@@ -49,6 +49,7 @@
     "@brave/react-virtualized-auto-sizer": "^1.0.4",
     "@types/react-window": "^1.8.2",
     "@types/styled-components": "^5.1.25",
+    "async": "^3.2.4",
     "bignumber.js": "^9.1.0",
     "ethereum-blockies": "github:brave/blockies",
     "react": "^16.14.0",
@@ -57,6 +58,7 @@
     "styled-components": "^5.3.5"
   },
   "devDependencies": {
+    "@types/async": "^3.2.15",
     "@types/node": "^18.7.20",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",

--- a/interface/src/components/swap/account-modal/account-modal.tsx
+++ b/interface/src/components/swap/account-modal/account-modal.tsx
@@ -35,7 +35,7 @@ import {
 
 interface Props {
   onHideModal: () => void
-  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => Promise<void>
 }
 
 export const AccountModal = (props: Props) => {
@@ -57,7 +57,7 @@ export const AccountModal = (props: Props) => {
       await refreshBlockchainState({ account })
       onHideModal()
     },
-    [onHideModal, switchAccount]
+    [onHideModal, switchAccount, refreshBlockchainState]
   )
   const onDisconnect = React.useCallback(async () => {
     if (disconnectWallet) {

--- a/interface/src/components/swap/header.tsx
+++ b/interface/src/components/swap/header.tsx
@@ -29,7 +29,7 @@ import { useOnClickOutside } from '~/hooks/useOnClickOutside'
 import { Row, HorizontalSpacer, StyledDiv } from '~/components/shared.styles'
 
 interface Props {
-  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => Promise<void>
 }
 
 export const Header = (props: Props) => {
@@ -50,8 +50,8 @@ export const Header = (props: Props) => {
   // Methods
   const onSelectNetwork = React.useCallback(async (network: NetworkInfo) => {
     await switchNetwork(network)
-    await refreshBlockchainState({ network })
     setShowNetworkSelector(false)
+    await refreshBlockchainState({ network })
   }, [switchNetwork, refreshBlockchainState])
 
   const toggleTheme = React.useCallback(() => {

--- a/interface/src/components/swap/search-with-network-selector.tsx
+++ b/interface/src/components/swap/search-with-network-selector.tsx
@@ -27,7 +27,7 @@ interface Props {
   onSearchChanged: (value: string) => void
   searchValue: string
   networkSelectorDisabled: boolean
-  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => Promise<void>
 }
 
 export const SearchWithNetworkSelector = (props: Props) => {
@@ -42,10 +42,10 @@ export const SearchWithNetworkSelector = (props: Props) => {
   const onSelectNetwork = React.useCallback(
     async (network: NetworkInfo) => {
       await switchNetwork(network)
-      await refreshBlockchainState({ network })
       setShowNetworkSelector(false)
+      await refreshBlockchainState({ network })
     },
-    [switchNetwork]
+    [switchNetwork, refreshBlockchainState]
   )
 
   return (

--- a/interface/src/components/swap/select-token-modal.tsx
+++ b/interface/src/components/swap/select-token-modal.tsx
@@ -28,16 +28,16 @@ import { Column, Row, Text, VerticalDivider, IconButton } from '~/components/sha
 interface Props {
   onClose: () => void
   onSelectToken: (token: BlockchainToken) => void
-  getAssetBalance: (token: BlockchainToken) => Amount
+  getCachedAssetBalance: (token: BlockchainToken) => Amount
   disabledToken: BlockchainToken | undefined
   selectingFromOrTo: 'from' | 'to'
-  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => Promise<void>
   getNetworkAssetsList: (network: NetworkInfo) => BlockchainToken[]
 }
 
 export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
   (props: Props, forwardedRef) => {
-    const { onClose, onSelectToken, getAssetBalance, refreshBlockchainState, getNetworkAssetsList, disabledToken, selectingFromOrTo } = props
+    const { onClose, onSelectToken, getCachedAssetBalance, refreshBlockchainState, getNetworkAssetsList, disabledToken, selectingFromOrTo } = props
 
     // Context
     const { getLocale, network, isWalletConnected } = useSwapContext()
@@ -80,9 +80,9 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
 
     const tokenListWithBalances: BlockchainToken[] = React.useMemo(() => {
       return filteredTokenListBySearch.filter((token: BlockchainToken) =>
-        getAssetBalance(token).gt(0)
+        getCachedAssetBalance(token).gt(0)
       )
-    }, [filteredTokenListBySearch, getAssetBalance])
+    }, [filteredTokenListBySearch, getCachedAssetBalance])
 
     const filteredTokenList: BlockchainToken[] = React.useMemo(() => {
       if (tokenListWithBalances.length === 0 || !isWalletConnected) {
@@ -131,7 +131,7 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
           {filteredTokenList.length !== 0 && (
             <VirtualizedTokenList
               disabledToken={disabledToken}
-              getAssetBalance={getAssetBalance}
+              getCachedAssetBalance={getCachedAssetBalance}
               isWalletConnected={isWalletConnected}
               onSelectToken={onSelectToken}
               tokenList={filteredTokenList}

--- a/interface/src/components/swap/swap-container.tsx
+++ b/interface/src/components/swap/swap-container.tsx
@@ -20,7 +20,7 @@ import { RefreshBlockchainStateParams } from '~/constants/types'
 
 interface Props {
   children?: React.ReactNode
-  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => void
+  refreshBlockchainState: (overrides: Partial<RefreshBlockchainStateParams>) => Promise<void>
 }
 
 export const SwapContainer = (props: Props) => {

--- a/interface/src/components/swap/virtualized-tokens-list.tsx
+++ b/interface/src/components/swap/virtualized-tokens-list.tsx
@@ -16,7 +16,7 @@ import Amount from '~/utils/amount'
 interface VirtualizedTokensListProps {
   tokenList: BlockchainToken[]
   onSelectToken: (token: BlockchainToken) => void
-  getAssetBalance: (token: BlockchainToken) => Amount
+  getCachedAssetBalance: (token: BlockchainToken) => Amount
   disabledToken: BlockchainToken | undefined
   isWalletConnected: boolean
 }
@@ -38,7 +38,7 @@ const ListItem = (props: ListItemProps) => {
   const {
     index,
     data,
-    getAssetBalance,
+    getCachedAssetBalance,
     disabledToken,
     isWalletConnected,
     onSelectToken,
@@ -50,7 +50,7 @@ const ListItem = (props: ListItemProps) => {
     <div style={style}>
       <TokenListButton
         onClick={onSelectToken}
-        balance={getAssetBalance(token)}
+        balance={getCachedAssetBalance(token)}
         isWalletConnected={isWalletConnected}
         token={token}
         disabled={
@@ -67,7 +67,7 @@ export const VirtualizedTokenList = (props: VirtualizedTokensListProps) => {
   const {
     tokenList,
     disabledToken,
-    getAssetBalance,
+    getCachedAssetBalance,
     isWalletConnected,
     onSelectToken
   } = props
@@ -93,7 +93,7 @@ export const VirtualizedTokenList = (props: VirtualizedTokensListProps) => {
             children={(itemProps) => (
               <ListItem
                 {...itemProps}
-                getAssetBalance={getAssetBalance}
+                getCachedAssetBalance={getCachedAssetBalance}
                 disabledToken={disabledToken}
                 isWalletConnected={isWalletConnected}
                 onSelectToken={onSelectToken}

--- a/interface/src/views/swap.tsx
+++ b/interface/src/views/swap.tsx
@@ -8,9 +8,10 @@ import styled from 'styled-components'
 
 // Types
 import { CoinType } from '~/constants/types'
+import Amount from '~/utils/amount'
 
 // Constants
-import { BRAVE_SWAP_DATA_THEME_KEY } from '../constants/magics'
+import { BRAVE_SWAP_DATA_THEME_KEY } from '~/constants/magics'
 
 // Context
 import { useSwapContext } from '~/context/swap.context'
@@ -52,7 +53,7 @@ export const Swap = () => {
     quoteOptions,
     selectedQuoteOptionIndex,
     selectingFromOrTo,
-    fromTokenBalance,
+    fromAssetBalance,
     fiatValue,
     swapAndSendSelected,
     toAnotherAddress,
@@ -64,7 +65,7 @@ export const Swap = () => {
     useDirectRoute,
     useOptimizedFees,
     gasEstimates,
-    getAssetBalance,
+    getCachedAssetBalance,
     onSelectFromToken,
     onSelectToToken,
     onSelectQuoteOption,
@@ -162,7 +163,7 @@ export const Swap = () => {
           inputValue={fromAmount}
           onClickSelectToken={() => setSelectingFromOrTo('from')}
           token={fromToken}
-          tokenBalance={fromTokenBalance}
+          tokenBalance={fromAssetBalance}
           hasInputError={
             swapValidationError === 'insufficientBalance' ||
             swapValidationError === 'fromAmountDecimalsOverflow'
@@ -227,7 +228,7 @@ export const Swap = () => {
             selectingFromOrTo === 'from' ? onSelectFromToken : onSelectToToken
           }
           disabledToken={selectingFromOrTo === 'from' ? toToken : fromToken}
-          getAssetBalance={getAssetBalance}
+          getCachedAssetBalance={getCachedAssetBalance}
           selectingFromOrTo={selectingFromOrTo}
           refreshBlockchainState={refreshBlockchainState}
           getNetworkAssetsList={getNetworkAssetsList}

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,13 +23,14 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave-experiments/leo",
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
         "@types/react-window": "^1.8.2",
         "@types/styled-components": "^5.1.25",
+        "async": "^3.2.4",
         "bignumber.js": "^9.1.0",
         "ethereum-blockies": "github:brave/blockies",
         "react": "^16.14.0",
@@ -38,6 +39,7 @@
         "styled-components": "^5.3.5"
       },
       "devDependencies": {
+        "@types/async": "^3.2.15",
         "@types/node": "^18.7.20",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.1",
@@ -3718,12 +3720,14 @@
       "requires": {
         "@brave/leo": "github:brave-experiments/leo",
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
+        "@types/async": "^3.2.15",
         "@types/node": "^18.7.20",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.1",
         "@types/react-window": "^1.8.2",
         "@types/styled-components": "^5.1.25",
         "@vitejs/plugin-react": "2.1.0",
+        "async": "^3.2.4",
         "bignumber.js": "^9.1.0",
         "ethereum-blockies": "github:brave/blockies",
         "react": "^16.14.0",


### PR DESCRIPTION
Balance updates just got a makeover! Here's how it works:

- We maintain a balance registry which is gradually populated. Think of it as a cache. Until the cached balance is populated for a particular token, the balance is considered zero.
- On changing the From asset, we fetch the live balance for the new token and update the cache.
- On first load of the swap app, we fetch balances for all available tokens, and populate the cache. This is done in a throttled manner so as to not overwhelm the event loop. We currently use 10 concurrent workers, and split the tokens list in chunks of 10 so we don't have to wait for all balances to be available before starting to see them in the UI.

### Demo

https://user-images.githubusercontent.com/3684187/199628575-1ba223c6-8b80-4f45-9b4e-4c3988ee1407.mov


