### PR TITLE
chore: disable swap and send until it works

### DIFF
--- a/interface/src/hooks/useSwap.ts
+++ b/interface/src/hooks/useSwap.ts
@@ -86,7 +86,7 @@ export const useSwap = () => {
   const [userConfirmedAddress, setUserConfirmedAddress] = React.useState<boolean>(false)
   const [selectedSwapSendAccount, setSelectedSwapSendAccount] = React.useState<
     WalletAccount | undefined
-  >(undefined)
+  >(account)
   const [useDirectRoute, setUseDirectRoute] = React.useState<boolean>(false)
   const [useOptimizedFees, setUseOptimizedFees] = React.useState<boolean>(false)
   const [slippageTolerance, setSlippageTolerance] = React.useState<string>('0.5')
@@ -114,7 +114,11 @@ export const useSwap = () => {
     slippagePercentage: new Amount(slippageTolerance).toNumber()
   })
   const zeroEx = useZeroEx({
-    takerAddress: selectedSwapSendAccount?.address || account.address,
+    takerAddress: swapAndSendSelected
+      ? selectedSwapAndSendOption === 'to-account'
+        ? selectedSwapSendAccount?.address || account.address
+        : toAnotherAddress
+      : account.address,
     fromAmount,
     toAmount: '',
     fromToken,

--- a/interface/src/views/swap.tsx
+++ b/interface/src/views/swap.tsx
@@ -54,11 +54,6 @@ export const Swap = () => {
     selectingFromOrTo,
     fromTokenBalance,
     fiatValue,
-    swapAndSendSelected,
-    toAnotherAddress,
-    userConfirmedAddress,
-    selectedSwapSendAccount,
-    selectedSwapAndSendOption,
     selectedGasFeeOption,
     slippageTolerance,
     useDirectRoute,
@@ -72,11 +67,6 @@ export const Swap = () => {
     setSelectingFromOrTo,
     handleOnSetFromAmount,
     handleOnSetToAmount,
-    handleOnSetToAnotherAddress,
-    onCheckUserConfirmedAddress,
-    onSetSelectedSwapAndSendOption,
-    setSelectedSwapSendAccount,
-    setSwapAndSendSelected,
     setSelectedGasFeeOption,
     setSlippageTolerance,
     setUseDirectRoute,
@@ -196,18 +186,20 @@ export const Swap = () => {
               toToken={toToken}
               toAmount={toAmount}
             />
-            <SwapAndSend
-              onChangeSwapAndSendSelected={setSwapAndSendSelected}
-              handleOnSetToAnotherAddress={handleOnSetToAnotherAddress}
-              onCheckUserConfirmedAddress={onCheckUserConfirmedAddress}
-              onSelectSwapAndSendOption={onSetSelectedSwapAndSendOption}
-              onSelectSwapSendAccount={setSelectedSwapSendAccount}
-              swapAndSendSelected={swapAndSendSelected}
-              selectedSwapAndSendOption={selectedSwapAndSendOption}
-              selectedSwapSendAccount={selectedSwapSendAccount}
-              toAnotherAddress={toAnotherAddress}
-              userConfirmedAddress={userConfirmedAddress}
-            />
+
+            {/* TODO: Swap and Send  is currently unavailable
+              <SwapAndSend
+                onChangeSwapAndSendSelected={setSwapAndSendSelected}
+                handleOnSetToAnotherAddress={handleOnSetToAnotherAddress}
+                onCheckUserConfirmedAddress={onCheckUserConfirmedAddress}
+                onSelectSwapAndSendOption={onSetSelectedSwapAndSendOption}
+                onSelectSwapSendAccount={setSelectedSwapSendAccount}
+                swapAndSendSelected={swapAndSendSelected}
+                selectedSwapAndSendOption={selectedSwapAndSendOption}
+                selectedSwapSendAccount={selectedSwapSendAccount}
+                toAnotherAddress={toAnotherAddress}
+                userConfirmedAddress={userConfirmedAddress}
+            */}
           </>
         )}
         <StandardButton


### PR DESCRIPTION
Swap and Send apparently doesn't work with 0x using a custom taker address. I will check with 0x during our next group call, but until it's resolved, let's disable this feature.