### PR TITLE
chore: add postcss-js to dev-dependencies

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",
@@ -16,10 +16,12 @@
         "async": "^3.2.4",
         "bignumber.js": "^9.1.0",
         "ethereum-blockies": "github:brave/blockies",
+        "postcss-js": "^4.0.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-window": "^1.8.5",
-        "styled-components": "^5.3.0"
+        "styled-components": "^5.3.0",
+        "svelte2tsx": "^0.5.20"
       },
       "devDependencies": {
         "@types/async": "^3.2.15",
@@ -27,7 +29,6 @@
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.1",
         "@vitejs/plugin-react": "2.1.0",
-        "svelte2tsx": "^0.5.20",
         "typescript": "^4.6.4",
         "vite": "^3.0.0",
         "vite-plugin-dts": "1.6.6"
@@ -606,12 +607,12 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#f8c37d5a696194985c35533b16da45412138ce3f",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#4737866282054c448936f86558cdec70bf7f064a",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^3.4.0",
-        "@tsconfig/svelte": "^2.0.0",
+        "@tsconfig/svelte": "^3.0.0",
         "lodash.merge": "^4.6.2",
         "style-dictionary": "^3",
         "svelte": "^3.50.1",
@@ -1691,9 +1692,9 @@
       }
     },
     "node_modules/@tsconfig/svelte": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-2.0.1.tgz",
-      "integrity": "sha512-aqkICXbM1oX5FfgZd2qSSAGdyo/NRxjWCamxoyi3T8iVQnzGge19HhDYzZ6NrVOW7bhcWNSq9XexWFtMzbB24A=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-3.0.0.tgz",
+      "integrity": "sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg=="
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
@@ -2612,8 +2613,7 @@
     "node_modules/dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
-      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
-      "dev": true
+      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -6452,7 +6452,6 @@
       "version": "0.5.20",
       "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.5.20.tgz",
       "integrity": "sha512-yNHmN/uoAnJ7d1XqVohiNA6TMFOxibHyEddUAHVt1PiLXtbwAJF3WaGYlg8QbOdoXzOVsVNCAlqRUIdULUm+OA==",
-      "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
         "pascal-case": "^3.1.1"
@@ -7441,11 +7440,11 @@
       "peer": true
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#f8c37d5a696194985c35533b16da45412138ce3f",
+      "version": "git+ssh://git@github.com/brave/leo.git#4737866282054c448936f86558cdec70bf7f064a",
       "from": "@brave/leo@github:brave/leo",
       "requires": {
         "@ctrl/tinycolor": "^3.4.0",
-        "@tsconfig/svelte": "^2.0.0",
+        "@tsconfig/svelte": "^3.0.0",
         "lodash.merge": "^4.6.2",
         "style-dictionary": "^3",
         "svelte": "^3.50.1",
@@ -8309,9 +8308,9 @@
       }
     },
     "@tsconfig/svelte": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-2.0.1.tgz",
-      "integrity": "sha512-aqkICXbM1oX5FfgZd2qSSAGdyo/NRxjWCamxoyi3T8iVQnzGge19HhDYzZ6NrVOW7bhcWNSq9XexWFtMzbB24A=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-3.0.0.tgz",
+      "integrity": "sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg=="
     },
     "@types/argparse": {
       "version": "1.0.38",
@@ -9046,8 +9045,7 @@
     "dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
-      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
-      "dev": true
+      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -11828,7 +11826,6 @@
       "version": "0.5.20",
       "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.5.20.tgz",
       "integrity": "sha512-yNHmN/uoAnJ7d1XqVohiNA6TMFOxibHyEddUAHVt1PiLXtbwAJF3WaGYlg8QbOdoXzOVsVNCAlqRUIdULUm+OA==",
-      "dev": true,
       "requires": {
         "dedent-js": "^1.0.1",
         "pascal-case": "^3.1.1"

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",
@@ -52,10 +52,12 @@
     "async": "^3.2.4",
     "bignumber.js": "^9.1.0",
     "ethereum-blockies": "github:brave/blockies",
+    "postcss-js": "^4.0.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-window": "^1.8.5",
-    "styled-components": "^5.3.0"
+    "styled-components": "^5.3.0",
+    "svelte2tsx": "^0.5.20"
   },
   "devDependencies": {
     "@types/async": "^3.2.15",
@@ -63,7 +65,6 @@
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
     "@vitejs/plugin-react": "2.1.0",
-    "svelte2tsx": "^0.5.20",
     "typescript": "^4.6.4",
     "vite": "^3.0.0",
     "vite-plugin-dts": "1.6.6"

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",
@@ -33,10 +33,12 @@
         "async": "^3.2.4",
         "bignumber.js": "^9.1.0",
         "ethereum-blockies": "github:brave/blockies",
+        "postcss-js": "^4.0.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-window": "^1.8.5",
-        "styled-components": "^5.3.0"
+        "styled-components": "^5.3.0",
+        "svelte2tsx": "^0.5.20"
       },
       "devDependencies": {
         "@types/async": "^3.2.15",
@@ -44,7 +46,6 @@
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.1",
         "@vitejs/plugin-react": "2.1.0",
-        "svelte2tsx": "^0.5.20",
         "typescript": "^4.6.4",
         "vite": "^3.0.0",
         "vite-plugin-dts": "1.6.6"
@@ -3731,6 +3732,7 @@
         "async": "^3.2.4",
         "bignumber.js": "^9.1.0",
         "ethereum-blockies": "github:brave/blockies",
+        "postcss-js": "^4.0.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-window": "^1.8.5",


### PR DESCRIPTION
Couldn't install swap-interface in brave-core without having this as a dev dependency, as leo depends on it for the build.