### PR TITLE
feat: add input debouncing, in-flight cancellation, and reset improvements

### DIFF
--- a/interface/src/hooks/useDebouncedCallback.ts
+++ b/interface/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { useEffect, useRef, useCallback } from 'react'
+
+export function useDebouncedCallback<A extends any[]> (
+  callback: (...args: A) => void,
+  wait: number
+) {
+  // Track args & timeout handle between calls
+  const argsRef = useRef<A>()
+  const timeout = useRef<ReturnType<typeof setTimeout>>()
+
+  const cleanup = useCallback(() => {
+    if (timeout.current) {
+      clearTimeout(timeout.current)
+    }
+  }, [timeout])
+
+  // Make sure our timeout gets cleared if our consuming component gets
+  // unmounted.
+  useEffect(() => cleanup, [cleanup])
+
+  return useCallback(
+    function debouncedCallback (...args: A) {
+      // capture latest args
+      argsRef.current = args
+
+      // clear debounce timer
+      cleanup()
+
+      // start waiting again
+      timeout.current = setTimeout(() => {
+        if (argsRef.current) {
+          callback(...argsRef.current)
+        }
+      }, wait)
+    },
+    [argsRef, timeout, cleanup, callback, wait]
+  )
+}

--- a/interface/src/vite-env.d.ts
+++ b/interface/src/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite/client" />
+import 'vite/client'


### PR DESCRIPTION
This PR introduces two main features:
1. Inputs are debounced to prevent triggering refresh of quotes too often.
2. Fetching of quotes can be cancelled in-flight due to a reset.

## Test Plan

### High level:
1. If a quote is being fetched, clearing the either of the From or To inputs should cancel the fetch.
2. New quotes are only fetched after 700ms of the last update to the From or To amounts.

### Testing reset scenarios
- Clearing From amount, using Ctrl+A following by Delete, should reset the quotes.
- Clearing To amount, using Ctrl+A following by Delete, should reset the quotes.
- Enter a very long amount in the From field, such as `1.23456789`. Long press the Delete key until all entire amount is cleared. This should trigger a reset and not result in a zombie quote (a quote that exists without either From or To amounts).
- Changing the From token should trigger a full reset.
- Changing the To token should trigger a reset of To amount, and refresh the quotes without debounce.