### PR TITLE
fix: disable CTA button for Solana validation errors

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/hooks/useSwap.ts
+++ b/interface/src/hooks/useSwap.ts
@@ -724,7 +724,8 @@ export const useSwap = () => {
       // the transaction is an ERC20Approve, Swap button must be disabled.
       (swapValidationError &&
         network.coin === CoinType.Ethereum &&
-        swapValidationError !== 'insufficientAllowance')
+        swapValidationError !== 'insufficientAllowance') ||
+      (swapValidationError && network.coin === CoinType.Solana)
     )
   }, [
     zeroEx.loading,

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",


### PR DESCRIPTION
Added the missing condition for Solana, to disable the CTA button in case of errors.

|Issue|https://github.com/brave/brave-browser/issues/28623|
-|-
