### PR TITLE
fix: prevent duplicate blockchain state refresh on first load

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/hooks/useDebouncedCallback.ts
+++ b/interface/src/hooks/useDebouncedCallback.ts
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 
 export function useDebouncedCallback<A extends any[]> (
-  callback: (...args: A) => void,
+  callback: (...args: A) => Promise<void>,
   wait: number
 ) {
   // Track args & timeout handle between calls
@@ -24,7 +24,7 @@ export function useDebouncedCallback<A extends any[]> (
   useEffect(() => cleanup, [cleanup])
 
   return useCallback(
-    function debouncedCallback (...args: A) {
+    async function debouncedCallback (...args: A) {
       // capture latest args
       argsRef.current = args
 
@@ -32,9 +32,9 @@ export function useDebouncedCallback<A extends any[]> (
       cleanup()
 
       // start waiting again
-      timeout.current = setTimeout(() => {
+      timeout.current = setTimeout(async () => {
         if (argsRef.current) {
-          callback(...argsRef.current)
+          await callback(...argsRef.current)
         }
       }, wait)
     },

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",


### PR DESCRIPTION
Use debounced version of `refreshBlockchainState()` and `refreshSpotPrices()` on first load. This prevents Swap from calling these functions multiple times (due to changing hook dependencies) on initialisation.

The code works with a 0ms debounce, but I don't know why. I tested this PR with `console.log` statements.

|Issue|https://github.com/brave/brave-browser/issues/28635|
-|-