### PR TITLE
feat: integrate token balances scanner

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.15.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "0.15.2",
+      "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "0.15.2",
+  "version": "1.0.0",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -39,6 +39,7 @@ const App = (props: AppProps) => {
     switchNetwork,
     getBalance,
     getTokenBalance,
+    getTokenBalances,
     getLocale,
     getTokenPrice,
     getNetworkFeeEstimate,
@@ -65,6 +66,7 @@ const App = (props: AppProps) => {
         switchNetwork={switchNetwork}
         getBalance={getBalance}
         getTokenBalance={getTokenBalance}
+        getTokenBalances={getTokenBalances}
         getLocale={getLocale}
         getTokenPrice={getTokenPrice}
         getNetworkFeeEstimate={getNetworkFeeEstimate}

--- a/interface/src/context/swap.context.tsx
+++ b/interface/src/context/swap.context.tsx
@@ -35,6 +35,12 @@ interface SwapContextInterface {
     coin: number,
     chainId: string
   ) => Promise<string>
+  getTokenBalances: (
+    contractAddress: string[],
+    address: string,
+    coin: number,
+    chainId: string
+  ) => Promise<{ [contractAddress: string]: string }>
   assetsList: BlockchainToken[]
   account?: WalletAccount
   network: NetworkInfo
@@ -103,6 +109,7 @@ const SwapProvider = (props: SwapProviderInterface) => {
     getLocale,
     getBalance,
     getTokenBalance,
+    getTokenBalances,
     getTokenPrice,
     getNetworkFeeEstimate,
     ethWalletAdapter,
@@ -129,6 +136,7 @@ const SwapProvider = (props: SwapProviderInterface) => {
         getLocale,
         getBalance,
         getTokenBalance,
+        getTokenBalances,
         getTokenPrice,
         getNetworkFeeEstimate,
         ethWalletAdapter,

--- a/interface/src/utils/assets.ts
+++ b/interface/src/utils/assets.ts
@@ -18,3 +18,7 @@ export const makeNetworkAsset = (network: NetworkInfo): BlockchainToken => {
 export const getBalanceRegistryKey = (asset: BlockchainToken) => {
   return `${asset.coin}-${asset.chainId}-${asset.contractAddress.toLowerCase()}`
 }
+
+export const getBalanceRegistryKeyRaw = (coin: number, chainId: string, contract: string) => {
+  return `${coin}-${chainId}-${contract.toLowerCase()}`
+}

--- a/sites/mock/mock-data/mock-apis.ts
+++ b/sites/mock/mock-data/mock-apis.ts
@@ -47,6 +47,15 @@ export const getTokenBalance = async (
   return balance ?? '0'
 }
 
+export const getTokenBalances = async (
+    contract: string[],
+    address: string,
+    coin: number,
+    chainId: string
+) => {
+  return mockEVMNetworksData[address][chainId].erc20Balances
+}
+
 export const getTokenPrice = async (token: BlockchainToken) => {
   const price = mockSpotPrices[token.contractAddress]
   if (!price) {

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "0.15.2",
+      "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",

--- a/sites/mock/src/main.tsx
+++ b/sites/mock/src/main.tsx
@@ -10,6 +10,7 @@ import {
   ethWalletAdapter,
   getBalance,
   getTokenBalance,
+  getTokenBalances,
   getNetworkFeeEstimate,
   getTokenPrice,
   solWalletAdapter,
@@ -60,6 +61,7 @@ function SwapContainer() {
       getLocale={getLocale}
       getBalance={getBalance}
       getTokenBalance={getTokenBalance}
+      getTokenBalances={getTokenBalances}
       getTokenPrice={getTokenPrice}
       getNetworkFeeEstimate={getNetworkFeeEstimate}
       ethWalletAdapter={ethWalletAdapter}


### PR DESCRIPTION
|Issue|https://github.com/brave/brave-browser/issues/28634|
-|-

⚠️ This PR is compatible only with brave-core 1.50.x. The MAJOR version has been bumped due to change in interface.

## Comparison of time taken to scan all token balances

### On page load

|   |Before|After|
|--|-------|----|
|**Ethereum**|45s|4s|
|**Polygon**|13s|4s|
|**Optimism**|9s|4s|
|**BSC**|12s|2s|

### On switch network

|   |Before|After|
|--|-------|----|
|**Ethereum**|20s|2s|
|**Polygon**|6s|2s|
|**Optimism**|4s|2s|
|**BSC**|4s|1s|