### PR TITLE
chore: hardcode swapMode to ExactIn + cleanups

### DIFF
--- a/interface/src/constants/types.ts
+++ b/interface/src/constants/types.ts
@@ -143,7 +143,7 @@ export type SwapParams = {
   fromAmount: string
   toAmount: string
   slippagePercentage: number
-  takerAddress?: string
+  fromAddress?: string
 }
 
 export type ZeroExSwapParams = {
@@ -186,10 +186,16 @@ export interface ZeroExSwapResponse extends ZeroExQuoteResponse {
   data: string
 }
 
+interface ZeroExValidationError {
+  field: string
+  code: number
+  reason: string
+}
+
 export interface ZeroExErrorResponse {
   code: number
   reason: string
-  validationErrors?: Array<{ field: string; code: number; reason: string }>
+  validationErrors?: ZeroExValidationError[]
   isInsufficientLiquidity: boolean
 }
 
@@ -207,7 +213,6 @@ export type JupiterQuoteParams = {
   inputMint: string
   outputMint: string
   amount: string
-  swapMode: string
   slippageBps: number
   userPublicKey: string
 }

--- a/interface/src/hooks/useNativeAsset.ts
+++ b/interface/src/hooks/useNativeAsset.ts
@@ -13,6 +13,7 @@ export const useNativeAsset = () => {
   const { network } = useSwapContext()
   return React.useMemo(
     () => makeNetworkAsset(network),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       network.chainId,
       network.coin,

--- a/interface/src/hooks/useSwap.ts
+++ b/interface/src/hooks/useSwap.ts
@@ -110,21 +110,17 @@ export const useSwap = () => {
     fromToken,
     toToken,
     fromAmount,
-    toAmount,
+    toAmount: '',
     slippagePercentage: new Amount(slippageTolerance).toNumber(),
-    takerAddress: account?.address
+    fromAddress: account?.address
   })
   const zeroEx = useZeroEx({
-    takerAddress: swapAndSendSelected
-      ? selectedSwapAndSendOption === 'to-account'
-        ? selectedSwapSendAccount?.address || account?.address
-        : toAnotherAddress
-      : account?.address,
     fromAmount,
     toAmount: '',
     fromToken,
     toToken,
-    slippagePercentage: new Amount(slippageTolerance).div(100).toNumber()
+    slippagePercentage: new Amount(slippageTolerance).div(100).toNumber(),
+    fromAddress: account?.address
   })
 
   const quoteOptions: QuoteOption[] = React.useMemo(() => {

--- a/interface/src/hooks/useZeroEx.ts
+++ b/interface/src/hooks/useZeroEx.ts
@@ -79,16 +79,17 @@ export function useZeroEx (params: SwapParams) {
       }
       const fromAmountWrapped = new Amount(overriddenParams.fromAmount)
       const toAmountWrapped = new Amount(overriddenParams.toAmount)
-      if (
-        (fromAmountWrapped.isZero() ||
-          fromAmountWrapped.isNaN() ||
-          fromAmountWrapped.isUndefined()) &&
-        (toAmountWrapped.isZero() || toAmountWrapped.isNaN() || toAmountWrapped.isUndefined())
-      ) {
+      const isFromAmountEmpty =
+        fromAmountWrapped.isZero() || fromAmountWrapped.isNaN() || fromAmountWrapped.isUndefined()
+      const isToAmountEmpty =
+        toAmountWrapped.isZero() || toAmountWrapped.isNaN() || toAmountWrapped.isUndefined()
+
+      if (isFromAmountEmpty && isToAmountEmpty) {
         await reset()
         return
       }
-      if (!overriddenParams.takerAddress) {
+
+      if (!overriddenParams.fromAddress) {
         return
       }
 
@@ -107,7 +108,7 @@ export function useZeroEx (params: SwapParams) {
       let priceQuoteResponse
       try {
         priceQuoteResponse = await swapService.getZeroExPriceQuote({
-          takerAddress: overriddenParams.takerAddress,
+          takerAddress: overriddenParams.fromAddress,
           sellAmount:
             overriddenParams.fromAmount &&
             new Amount(overriddenParams.fromAmount)
@@ -199,16 +200,19 @@ export function useZeroEx (params: SwapParams) {
       if (!overriddenParams.fromAmount && !overriddenParams.toAmount) {
         return
       }
-      if (!overriddenParams.takerAddress) {
-        return
-      }
 
       const fromAmountWrapped = new Amount(overriddenParams.fromAmount)
       const toAmountWrapped = new Amount(overriddenParams.toAmount)
-      if (
-        (fromAmountWrapped.isZero() || fromAmountWrapped.isNaN()) &&
-        (toAmountWrapped.isZero() || toAmountWrapped.isNaN())
-      ) {
+      const isFromAmountEmpty =
+        fromAmountWrapped.isZero() || fromAmountWrapped.isNaN() || fromAmountWrapped.isUndefined()
+      const isToAmountEmpty =
+        toAmountWrapped.isZero() || toAmountWrapped.isNaN() || toAmountWrapped.isUndefined()
+
+      if (isFromAmountEmpty && isToAmountEmpty) {
+        return
+      }
+
+      if (!overriddenParams.fromAddress) {
         return
       }
 
@@ -216,7 +220,7 @@ export function useZeroEx (params: SwapParams) {
       let transactionPayloadResponse
       try {
         transactionPayloadResponse = await swapService.getZeroExTransactionPayload({
-          takerAddress: overriddenParams.takerAddress,
+          takerAddress: overriddenParams.fromAddress,
           sellAmount: new Amount(overriddenParams.fromAmount)
             .multiplyByDecimals(overriddenParams.fromToken.decimals)
             .format(),

--- a/interface/src/views/swap.tsx
+++ b/interface/src/views/swap.tsx
@@ -179,7 +179,7 @@ export const Swap = () => {
             onInputChange={handleOnSetToAmount}
             hasInputError={swapValidationError === 'toAmountDecimalsOverflow'}
             isLoading={isFetchingQuote}
-            disabled={false}
+            disabled={network.coin === CoinType.Solana}
           />
           {network.coin === CoinType.Solana && quoteOptions.length > 0 && (
             <QuoteOptions


### PR DESCRIPTION
The Jupiter Swap UI is not ready for `swapMode=ExactOut`. This PR hardcodes it to `ExactIn` + does some code improvements and cleanups.

Also passing a `sendOption` of `maxRetries=2` for greater reliability of transaction broadcasts.