### PR TITLE
Enable minimum received amount after slippage for Jupiter

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/hooks/useJupiter.ts
+++ b/interface/src/hooks/useJupiter.ts
@@ -222,11 +222,12 @@ export function useJupiter (params: SwapParams) {
             // @ts-expect-error
             params.toToken.decimals
           ),
-          // FIXME: disable displaying the minimumToAmount, since it is
-          // applicable only for ExactIn swapMode. In case of ExactOut,
-          // minimumToAmount is static and equal to the toAmount. The more
-          // relevant thing to display would be maximumFromAmount.
-          minimumToAmount: undefined,
+          // TODO: minimumToAmount is applicable only for ExactIn swapMode.
+          // Create a maximumFromAmount field for ExactOut swapMode if needed.
+          minimumToAmount: new Amount(route.otherAmountThreshold.toString()).divideByDecimals(
+            // @ts-expect-error
+            params.toToken.decimals
+          ),
           fromToken: params.fromToken,
           toToken: params.toToken,
           rate: new Amount(route.outAmount.toString())


### PR DESCRIPTION
Since we do not support `ExactOut` swap mode, might as well enable minimum received amount.