### PR TITLE
feat: add AbortController to refresh() in useJupiter hook

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "1.0.1",
+      "version": "2.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",


### PR DESCRIPTION
To be able to cancel in-flight requests to Jupiter API.