### PR TITLE
fix: improve code clarity + prevent decimal slippageBps value

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brave/swap-interface",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brave/swap-interface",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/constants/types.ts
+++ b/interface/src/constants/types.ts
@@ -142,7 +142,9 @@ export type SwapParams = {
   toToken?: BlockchainToken
   fromAmount: string
   toAmount: string
-  slippagePercentage: number
+  // This is the value as seen on the UI - should be converted to appropriate
+  // format for Jupiter and 0x swap providers.
+  slippageTolerance: string
   fromAddress?: string
 }
 

--- a/interface/src/hooks/useJupiter.ts
+++ b/interface/src/hooks/useJupiter.ts
@@ -126,7 +126,10 @@ export function useJupiter (params: SwapParams) {
             : new Amount(overriddenParams.toAmount)
               .multiplyByDecimals(overriddenParams.toToken.decimals)
               .format(),
-          slippageBps: new Amount(overriddenParams.slippagePercentage).times(100).toNumber(),
+          slippageBps: new Amount(overriddenParams.slippageTolerance)
+            .times(100)
+            .parseInteger()
+            .toNumber(),
           userPublicKey: overriddenParams.fromAddress
         })
       } catch (e) {

--- a/interface/src/hooks/useSwap.ts
+++ b/interface/src/hooks/useSwap.ts
@@ -111,7 +111,7 @@ export const useSwap = () => {
     toToken,
     fromAmount,
     toAmount: '',
-    slippagePercentage: new Amount(slippageTolerance).toNumber(),
+    slippageTolerance,
     fromAddress: account?.address
   })
   const zeroEx = useZeroEx({
@@ -119,7 +119,7 @@ export const useSwap = () => {
     toAmount: '',
     fromToken,
     toToken,
-    slippagePercentage: new Amount(slippageTolerance).div(100).toNumber(),
+    slippageTolerance,
     fromAddress: account?.address
   })
 

--- a/interface/src/hooks/useZeroEx.ts
+++ b/interface/src/hooks/useZeroEx.ts
@@ -121,7 +121,7 @@ export function useZeroEx (params: SwapParams) {
               .multiplyByDecimals(overriddenParams.toToken.decimals)
               .format(),
           buyToken: overriddenParams.toToken.contractAddress || NATIVE_ASSET_CONTRACT_ADDRESS_0X,
-          slippagePercentage: overriddenParams.slippagePercentage,
+          slippagePercentage: new Amount(overriddenParams.slippageTolerance).div(100).toNumber(),
           gasPrice: ''
         })
       } catch (e) {
@@ -229,7 +229,7 @@ export function useZeroEx (params: SwapParams) {
             .multiplyByDecimals(overriddenParams.toToken.decimals)
             .format(),
           buyToken: overriddenParams.toToken.contractAddress || NATIVE_ASSET_CONTRACT_ADDRESS_0X,
-          slippagePercentage: overriddenParams.slippagePercentage,
+          slippagePercentage: new Amount(overriddenParams.slippageTolerance).div(100).toNumber(),
           gasPrice: ''
         })
       } catch (e) {

--- a/sites/mock/package-lock.json
+++ b/sites/mock/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../interface": {
       "name": "@brave/swap-interface",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/leo": "github:brave/leo",


### PR DESCRIPTION
`slippageTolerance` in `useSwap.ts` now describes the UI-level concept (i.e., value entered by the user) and the hooks specific to the swap provider make sure this value is transformed into appropriate format.

**For example:**
If user selects `0.5` in the UI as slippage tolerance, then:
 - `slippageTolerance` is `0.5`
 - `slippageBps` for Jupiter is `50`.
 - `slippagePercentage` for 0x is `0.005`.