### PR TITLE
feat: Moved help centre link from account modal to main container

### DIFF
--- a/interface/package.json
+++ b/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave/swap-interface",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Brave Swap - an open-source swap interface by Brave, focussed on usability and multi-chain support.",
   "type": "module",
   "license": "MPL-2.0",

--- a/interface/src/components/swap/account-modal/account-modal.tsx
+++ b/interface/src/components/swap/account-modal/account-modal.tsx
@@ -8,7 +8,6 @@ import styled from 'styled-components'
 
 // Assets
 import DisconnectIcon from '~/assets/disconnect-icon.svg'
-import HelpIcon from '~/assets/info-icon.svg'
 import CloseIcon from '~/assets/close-icon.svg'
 
 // Hiding Portfolio Section until we support it.
@@ -70,12 +69,6 @@ export const AccountModal = (props: Props) => {
 
     await onHideModal()
   }, [disconnectWallet, onHideModal])
-
-  const onClickHelpCenter = React.useCallback(() => {
-    window.open(
-      'https://support.brave.com/hc/en-us/articles/8155407080845-Brave-Swaps-FAQ'
-    )
-  }, [])
 
   return (
     <ModalBox>
@@ -143,11 +136,6 @@ export const AccountModal = (props: Props) => {
             onClick={onDisconnect}
           />
         )}
-        <AccountModalButton
-          text={getLocale('braveSwapHelpCenter')}
-          icon={HelpIcon}
-          onClick={onClickHelpCenter}
-        />
       </Column>
     </ModalBox>
   )

--- a/interface/src/components/swap/swap-container.tsx
+++ b/interface/src/components/swap/swap-container.tsx
@@ -38,6 +38,13 @@ export const SwapContainer = (props: Props) => {
   // Refs
   const ref = React.createRef<HTMLInputElement>()
 
+  // Methods
+  const onClickHelpCenter = React.useCallback(() => {
+    window.open(
+      'https://support.brave.com/hc/en-us/categories/360001059151-Brave-Wallet'
+    )
+  }, [])
+
   // Effects
   React.useEffect(() => {
     // Keeps track of the Swap Containers Height to update
@@ -58,7 +65,10 @@ export const SwapContainer = (props: Props) => {
         refreshBlockchainState={refreshBlockchainState}
       />
       <Container ref={ref}>{children}</Container>
-      <PrivacyButton onClick={showPrivacyModal}>{getLocale('braveSwapPrivacyPolicy')}</PrivacyButton>
+      <Row>
+        <ActionButton onClick={showPrivacyModal}>{getLocale('braveSwapPrivacyPolicy')}</ActionButton>
+        <ActionButton onClick={onClickHelpCenter}>{getLocale('braveSwapHelpCenter')}</ActionButton>
+      </Row>
       <Background
         height={backgroundHeight}
         network={network.chainId ?? ''}
@@ -177,7 +187,13 @@ const Container = styled(StyledDiv)`
   }
 `
 
-export const PrivacyButton = styled(StyledButton)`
+export const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+`
+
+export const ActionButton = styled(StyledButton)`
   font-family: 'Poppins';
   font-style: normal;
   font-weight: 500;


### PR DESCRIPTION
Resolves: https://github.com/brave/brave-browser/issues/30372

### Changes
Move `Help Centre` link button from account modal to beside `Privacy policy` and changed the URL to https://support.brave.com/hc/en-us/categories/360001059151-Brave-Wallet.

### Test plan
<img width="1463" alt="Screenshot 2023-05-18 at 10 48 16" src="https://github.com/brave/swap/assets/48117473/9a4e3726-1c44-45e4-99f2-5f0616e89001">
